### PR TITLE
Fix greposync.yml being required for help commands

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -21,7 +21,7 @@ func CreateCLI(version, commit, date string) {
 	t, err := time.Parse(dateLayout, date)
 	printer.CheckIfError(err)
 
-	c := cfg.NewDefaultConfig()
+	config = cfg.NewDefaultConfig()
 	globalFlags = []cli.Flag{
 		&cli.BoolFlag{
 			Name:    "verbose",
@@ -30,7 +30,7 @@ func CreateCLI(version, commit, date string) {
 		},
 		&cli.StringFlag{
 			Name:        "log-level",
-			Destination: &c.Log.Level,
+			Destination: &config.Log.Level,
 			Usage:       "Log level. Allowed values are [debug, info, warn, error].",
 			Value:       "info",
 		},
@@ -41,17 +41,13 @@ func CreateCLI(version, commit, date string) {
 		Version:              fmt.Sprintf("%s, commit %s, date %s", version, commit[0:7], t.Format(dateLayout)),
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
-			createUpdateCommand(c),
+			createUpdateCommand(config),
 		},
 		Compiled: t,
 		ExitErrHandler: func(context *cli.Context, err error) {
 			_ = cli.ShowCommandHelp(context, context.Command.Name)
 		},
-		Before: func(context *cli.Context) error {
-			return cfg.ParseConfig("gitreposync.yml", c)
-		},
 	}
-	config = c
 }
 
 // Run the CLI application

--- a/cli/update.go
+++ b/cli/update.go
@@ -54,6 +54,10 @@ func createUpdateCommand(c *cfg.Configuration) *cli.Command {
 }
 
 func validateUpdateCommand(ctx *cli.Context) error {
+	if err := cfg.ParseConfig("greposync.yml", config); err != nil {
+		return err
+	}
+
 	if err := validateGlobalFlags(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

* Fix `greposync.yml` being required for help commands

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
