### PR TITLE
Run repository updates in parallel

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,13 +4,11 @@
 
 ## Checklist
 
-- [ ] Keep pull requests small so they can be easily reviewed.
 - [ ] Categorize the PR by setting a good title and adding one of the labels:
       `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
       as they show up in the changelog
 - [ ] Update documentation.
 - [ ] Update tests.
-- [ ] Link this PR to related issues.
 
 <!--
 Remove items that do not apply. For completed items, change [ ] to [x].

--- a/cfg/cli/cli.go
+++ b/cfg/cli/cli.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/maps"
+	"github.com/urfave/cli/v2"
+)
+
+// Cli implements a urfave/cli command line provider.
+type Cli struct {
+	delim string
+	ko    *koanf.Koanf
+	ctx   *cli.Context
+}
+
+/*
+Provider returns a commandline flags provider that returns a nested map[string]interface{} where the nesting hierarchy of keys are defined by delim.
+For instance, the delim "." will convert the flag name `parent.child.key: 1` to `{parent: {child: {key: 1}}}`.
+It takes an optional (but recommended) Koanf instance to see if the the flags defined have been set from other providers, for instance, a config file.
+If they are not, then the default values of the flags are merged.
+If they do exist, the flag values are not merged but only the values that have been explicitly set in the command line are merged.
+*/
+func Provider(ctx *cli.Context, delim string, ko *koanf.Koanf) *Cli {
+	return &Cli{
+		delim: delim,
+		ko:    ko,
+		ctx:   ctx,
+	}
+}
+
+// Read reads the flag variables and returns a nested conf map.
+func (p *Cli) Read() (map[string]interface{}, error) {
+	mp := make(map[string]interface{})
+	if p.ctx.Command == nil {
+		return mp, nil
+	}
+	for _, flag := range p.ctx.Command.Flags {
+		flagName := flag.Names()[0]
+		val := p.ctx.Value(flagName)
+
+		// If the default value of the flag was never changed by the user,
+		// it should not override the value in the conf map (if it exists in the first place).
+		if !p.ctx.IsSet(flagName) {
+			if p.ko != nil {
+				if p.ko.Exists(flagName) {
+					continue
+				}
+			} else {
+				continue
+			}
+		}
+		mp[flagName] = val
+	}
+	return maps.Unflatten(mp, p.delim), nil
+}
+
+// ReadBytes is not supported.
+func (p *Cli) ReadBytes() ([]byte, error) {
+	return nil, errors.New("cli provider does not support this method")
+}
+
+// Watch is not supported.
+func (p *Cli) Watch(cb func(event interface{}, err error)) error {
+	return errors.New("cli provider does not support this method")
+}

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -3,19 +3,17 @@ package cfg
 import (
 	"strings"
 
+	"github.com/ccremer/greposync/cfg/cli"
 	"github.com/ccremer/greposync/printer"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
+	urfavecli "github.com/urfave/cli/v2"
 )
 
 // ParseConfig overrides given config defaults from file and with environment variables.
-func ParseConfig(configPath string, config *Configuration) error {
-	return loadConfigHierarchy(configPath, config)
-}
-
-func loadConfigHierarchy(configPath string, config *Configuration) error {
+func ParseConfig(configPath string, config *Configuration, ctx *urfavecli.Context) error {
 	koanfInstance := koanf.New(".")
 
 	// Load file
@@ -34,6 +32,11 @@ func loadConfigHierarchy(configPath string, config *Configuration) error {
 		s = strings.Replace(strings.ToLower(s), "_", "-", -1)
 		return s
 	}), nil); err != nil {
+		return err
+	}
+
+	// CLI flags
+	if err := koanfInstance.Load(cli.Provider(ctx, "-", koanfInstance), nil); err != nil {
 		return err
 	}
 

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -7,51 +7,51 @@ import (
 type (
 	// Configuration holds a strongly-typed tree of the main configuration
 	Configuration struct {
-		Project     *ProjectConfig
-		Log         *LogConfig
-		PullRequest *PullRequestConfig
-		Template    *TemplateConfig
-		Git         *GitConfig
+		Project     *ProjectConfig     `json:"project" koanf:"project"`
+		Log         *LogConfig         `json:"log" koanf:"log"`
+		PullRequest *PullRequestConfig `json:"pr" koanf:"pr"`
+		Template    *TemplateConfig    `json:"template" koanf:"template"`
+		Git         *GitConfig         `json:"git" koanf:"git"`
 	}
 	// ProjectConfig configures the project
 	ProjectConfig struct {
-		// RootDir is the directory where the various configuration files are found.
-		RootDir string
+		// RootDir is the local directory where the Git repositories are cloned into.
+		RootDir string `json:"rootDir" koanf:"rootDir"`
 		// Jobs is the number of parallel jobs to run.
 		// Requires a minimum of 1, supports a maximum of 8.
 		// 1 basically means that jobs are run in sequence.
 		// If this number is 2 or greater, then the logs are buffered and only displayed in case of errors.
-		Jobs int
+		Jobs int `json:"jobs" koanf:"jobs"`
 	}
 
 	// LogConfig configures the logging options
 	LogConfig struct {
-		Level string
+		Level string `json:"level" koanf:"level"`
 	}
 	// PullRequestConfig configures the pull request feature
 	PullRequestConfig struct {
-		Create bool
+		Create bool `json:"create" koanf:"create"`
 		// TargetBranch is the target remote branch of the pull request.
 		// If left empty, it will target the default branch.
-		TargetBranch string
+		TargetBranch string `json:"targetBranch" koanf:"targetBranch"`
 		// Labels is an array of issue labels to apply when creating a pull request.
 		// Labels on existing pull requests are not updated.
 		// It is not validated whether the labels exist, the API may or may not create non-existing labels dynamically.
-		Labels []string
+		Labels []string `json:"labels" koanf:"labels"`
 		// BodyTemplate is the description used in pull requests.
 		// Supports Go template with the `.Metadata` key.
 		// If this string is a relative path to an existing file in the greposync directory, the file is parsed as a Go template.
 		// If empty, the CommitMessage is used.
-		BodyTemplate string
+		BodyTemplate string `json:"bodyTemplate" koanf:"bodyTemplate"`
 		// Subject is the Pull Request title.
-		Subject string
+		Subject string `json:"subject" koanf:"subject"`
 	}
 
 	// SyncConfig configures a single repository sync
 	SyncConfig struct {
-		PullRequest *PullRequestConfig
-		Git         *GitConfig
-		Template    *TemplateConfig
+		PullRequest *PullRequestConfig `json:"pullRequest"`
+		Git         *GitConfig         `json:"git"`
+		Template    *TemplateConfig    `json:"template"`
 	}
 	// GitConfig configures a git repository.
 	// This structure is used to configuring the sync behaviour
@@ -64,30 +64,30 @@ type (
 		// Dir is the relative path to current working directory where the repository is cloned locally.
 		// This option is not configurable in `greposync.yml`.
 		Dir        string `json:"-"`
-		SkipReset  bool
-		SkipCommit bool
-		SkipPush   bool
-		ForcePush  bool
+		SkipReset  bool   `json:"skipReset"`
+		SkipCommit bool   `json:"skipCommit"`
+		SkipPush   bool   `json:"skipPush"`
+		ForcePush  bool   `json:"forcePush"`
 		// Amend will amend the last commit.
 		// This option is not configurable in `greposync.yml`.
 		// Configurable only via environment variables or CLI flag.
-		Amend bool `json:"-"`
+		Amend bool `json:"-" koanf:"amend"`
 		// CommitMessage is the string that is passed to `git commit`.
 		// It can contain newlines, for example to pass a long description.
-		CommitMessage string
-		CommitBranch  string
+		CommitMessage string `json:"commitMessage" koanf:"commitMessage"`
+		CommitBranch  string `json:"commitBranch" koanf:"commitBranch"`
 		// DefaultBranch is the name of the default branch in origin.
-		DefaultBranch string
+		DefaultBranch string `json:"defaultBranch"`
 		// Name is the git repository name without .git extension.
-		Name string
+		Name string `json:"name"`
 		// Namespace is the repository owner without the repository name.
 		// This is often a user or organization name in GitHub.com or GitLab.com.
-		Namespace string
+		Namespace string `json:"namespace"`
 	}
 	// TemplateConfig configures template settings
 	TemplateConfig struct {
 		// RootDir is the path relative to the current workdir where the template files are located.
-		RootDir string
+		RootDir string `json:"rootDir" koanf:"rootDir"`
 	}
 )
 

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -7,12 +7,23 @@ import (
 type (
 	// Configuration holds a strongly-typed tree of the main configuration
 	Configuration struct {
-		ProjectRoot string
+		Project     *ProjectConfig
 		Log         *LogConfig
 		PullRequest *PullRequestConfig
 		Template    *TemplateConfig
 		Git         *GitConfig
 	}
+	// ProjectConfig configures the project
+	ProjectConfig struct {
+		// RootDir is the directory where the various configuration files are found.
+		RootDir string
+		// Jobs is the number of parallel jobs to run.
+		// Requires a minimum of 1, supports a maximum of 8.
+		// 1 basically means that jobs are run in sequence.
+		// If this number is 2 or greater, then the logs are buffered and only displayed in case of errors.
+		Jobs int
+	}
+
 	// LogConfig configures the logging options
 	LogConfig struct {
 		Level string
@@ -83,7 +94,10 @@ type (
 // NewDefaultConfig retrieves the hardcoded configs with sane defaults
 func NewDefaultConfig() *Configuration {
 	return &Configuration{
-		ProjectRoot: "repos",
+		Project: &ProjectConfig{
+			RootDir: "repos",
+			Jobs:    1,
+		},
 		Log: &LogConfig{
 			Level: "info",
 		},

--- a/cli/app.go
+++ b/cli/app.go
@@ -14,6 +14,8 @@ var (
 	app         *cli.App
 	globalFlags []cli.Flag
 	config      *cfg.Configuration
+	// ConfigDefaultName is the fallback file name of the YAML file containing the default template values.
+	ConfigDefaultName = "config_defaults.yml"
 )
 
 func CreateCLI(version, commit, date string) {
@@ -35,13 +37,14 @@ func CreateCLI(version, commit, date string) {
 			Value:       "info",
 		},
 	}
+	updateCommand := NewUpdateCommand(config)
 	app = &cli.App{
 		Name:                 "greposync",
 		Usage:                "git-repo-sync: Shameless reimplementation of ModuleSync in Go",
 		Version:              fmt.Sprintf("%s, commit %s, date %s", version, commit[0:7], t.Format(dateLayout)),
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
-			createUpdateCommand(config),
+			updateCommand.createUpdateCommand(),
 		},
 		Compiled: t,
 		ExitErrHandler: func(context *cli.Context, err error) {

--- a/cli/app.go
+++ b/cli/app.go
@@ -16,6 +16,12 @@ var (
 	config      *cfg.Configuration
 	// ConfigDefaultName is the fallback file name of the YAML file containing the default template values.
 	ConfigDefaultName = "config_defaults.yml"
+	// GrepoSyncFileName is the default file name of the YAML file containing the main settings.
+	GrepoSyncFileName = "greposync.yml"
+
+	logLevelFlagName    = "log-level"
+	projectRootFlagName = "project-root"
+	projectJobsFlagName = "project-jobs"
 )
 
 func CreateCLI(version, commit, date string) {
@@ -28,13 +34,23 @@ func CreateCLI(version, commit, date string) {
 		&cli.BoolFlag{
 			Name:    "verbose",
 			Aliases: []string{"v"},
-			Usage:   "Shorthand for --log-level=debug",
+			Usage:   fmt.Sprintf("Shorthand for --%s=debug", logLevelFlagName),
 		},
 		&cli.StringFlag{
-			Name:        "log-level",
-			Destination: &config.Log.Level,
-			Usage:       "Log level. Allowed values are [debug, info, warn, error].",
-			Value:       "info",
+			Name:  logLevelFlagName,
+			Usage: "Log level. Allowed values are [debug, info, warn, error].",
+			Value: config.Log.Level,
+		},
+		&cli.PathFlag{
+			Name:  projectRootFlagName,
+			Usage: "Local directory path where git clones repositories into.",
+			Value: config.Project.RootDir,
+		},
+		&cli.IntFlag{
+			Name:    projectJobsFlagName,
+			Usage:   "Jobs is the number of parallel jobs to run. 1 basically means that jobs are run in sequence.",
+			Aliases: []string{"j"},
+			Value:   1,
 		},
 	}
 	updateCommand := NewUpdateCommand(config)

--- a/docs/modules/ROOT/examples/config.yaml
+++ b/docs/modules/ROOT/examples/config.yaml
@@ -10,7 +10,9 @@ Git:
   SkipReset: false
 Log:
   Level: info
-ProjectRoot: repos
+Project:
+  Jobs: 1
+  RootDir: repos
 PullRequest:
   BodyTemplate: This Pull request updates this repository with changes from a greposync template repository.
   Create: false

--- a/docs/modules/ROOT/examples/config.yaml
+++ b/docs/modules/ROOT/examples/config.yaml
@@ -1,23 +1,23 @@
-Git:
-  CommitBranch: ""
-  CommitMessage: Update from greposync
-  DefaultBranch: ""
-  ForcePush: false
-  Name: ""
-  Namespace: ""
-  SkipCommit: false
-  SkipPush: false
-  SkipReset: false
-Log:
-  Level: info
-Project:
-  Jobs: 1
-  RootDir: repos
-PullRequest:
-  BodyTemplate: This Pull request updates this repository with changes from a greposync template repository.
-  Create: false
-  Labels: null
-  Subject: Update from greposync
-  TargetBranch: ""
-Template:
-  RootDir: template
+git:
+  commitBranch: ""
+  commitMessage: Update from greposync
+  defaultBranch: ""
+  forcePush: false
+  name: ""
+  namespace: ""
+  skipCommit: false
+  skipPush: false
+  skipReset: false
+log:
+  level: info
+pr:
+  bodyTemplate: This Pull request updates this repository with changes from a greposync template repository.
+  create: false
+  labels: null
+  subject: Update from greposync
+  targetBranch: ""
+project:
+  jobs: 1
+  rootDir: repos
+template:
+  rootDir: template

--- a/docs/modules/ROOT/pages/references/godoc.adoc
+++ b/docs/modules/ROOT/pages/references/godoc.adoc
@@ -15,7 +15,7 @@ include::example$config.yaml[]
 [source, go]
 ----
 type Configuration struct {
-    ProjectRoot    string
+    Project        *ProjectConfig
     Log            *LogConfig
     PullRequest    *PullRequestConfig
     Template       *TemplateConfig
@@ -45,6 +45,29 @@ func (config *Configuration) Sanitize()
 ----
 
 Sanitize does corrective actions on the configuration hierarchy.
+
+
+
+=== ProjectConfig
+[source, go]
+----
+type ProjectConfig struct {
+    RootDir    string
+    Jobs       int
+}
+----
+
+
+RootDir::
+RootDir is the directory where the various configuration files are found.
+
+Jobs::
+Jobs is the number of parallel jobs to run.
+Requires a minimum of 1, supports a maximum of 8.
+1 basically means that jobs are run in sequence.
+If this number is 2 or greater, then the logs are buffered and only displayed in case of errors.
+
+
 
 
 

--- a/docs/modules/ROOT/pages/references/godoc.adoc
+++ b/docs/modules/ROOT/pages/references/godoc.adoc
@@ -59,7 +59,7 @@ type ProjectConfig struct {
 
 
 RootDir::
-RootDir is the directory where the various configuration files are found.
+RootDir is the local directory where the Git repositories are cloned into.
 
 Jobs::
 Jobs is the number of parallel jobs to run.
@@ -219,6 +219,60 @@ RootDir::
 RootDir is the path relative to the current workdir where the template files are located.
 
 
+
+
+
+
+
+= package cli
+
+
+
+[source,yaml]
+----
+include::example$config.yaml[]
+----
+
+== Structs
+
+=== Cli
+[source, go]
+----
+type Cli struct {
+}
+----
+
+Cli implements a urfave/cli command line provider.
+
+
+
+
+
+==== Receivers
+
+===== Read
+[source, go]
+----
+func (p *Cli) Read() (map[string]interface{}, error)
+----
+
+Read reads the flag variables and returns a nested conf map.
+
+===== ReadBytes
+[source, go]
+----
+func (p *Cli) ReadBytes() ([]byte, error)
+----
+
+ReadBytes is not supported.
+
+===== Watch
+[source, go]
+----
+func (p *Cli) Watch(cb func(event interface{}, err error)) error
+----
+
+Watch is not supported.
 
 
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.1
 	github.com/ccremer/go-command-pipeline v0.2.0
 	github.com/google/go-github/v37 v37.0.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/knadh/koanf v1.1.1
 	github.com/mariotoffia/goasciidoc v0.4.5
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,7 @@ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -135,6 +136,8 @@ github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.0.1/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -49,7 +49,7 @@ func NewServicesFromFile(config *cfg.Configuration) []*Service {
 		s := &Service{
 			p: printer.New().MapColorToLevel(printer.Blue, printer.LevelInfo).SetLevel(printer.DefaultLevel).SetName(repoName),
 			Config: &cfg.GitConfig{
-				Dir:           path.Clean(path.Join(config.ProjectRoot, strings.ReplaceAll(u.Hostname(), ":", "-"), u.Path)),
+				Dir:           path.Clean(path.Join(config.Project.RootDir, strings.ReplaceAll(u.Hostname(), ":", "-"), u.Path)),
 				Url:           u,
 				ForcePush:     true,
 				SkipReset:     config.Git.SkipReset,


### PR DESCRIPTION
## Summary

* Add `--project-jobs` setting that runs repository updates in parallel, improving the speed for large template repositories.
* By default, parallelization is disabled resp. set to 1, which equals to running sequentially.
* Renames a number of CLI flags


## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
