### PR TITLE
Various fixes around git repository handling

### DIFF
--- a/repository/push.go
+++ b/repository/push.go
@@ -8,7 +8,7 @@ import (
 // PushToRemote invokes git to push the commits to origin.
 func (s *Service) PushToRemote() pipeline.ActionFunc {
 	return func() pipeline.Result {
-		args := []string{"push"}
+		args := []string{"push", "origin", s.Config.CommitBranch}
 		if s.Config.ForcePush {
 			args = append(args, "--force")
 		}


### PR DESCRIPTION
## Summary

* `--git-amend` now only amends a commit when there is a commit in the commit branch. This is to avoid amending merge commits
* Correctly creates new branches if they don't yet exist.
* Actually run updates in parallel by using the `--project-jobs` flag

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update documentation.
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
