### PR TITLE
Support filtering repositories

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -3,17 +3,17 @@ package cfg
 import (
 	"strings"
 
-	"github.com/ccremer/greposync/cfg/cli"
+	"github.com/ccremer/greposync/flag"
 	"github.com/ccremer/greposync/printer"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
-	urfavecli "github.com/urfave/cli/v2"
+	"github.com/urfave/cli/v2"
 )
 
 // ParseConfig overrides given config defaults from file and with environment variables.
-func ParseConfig(configPath string, config *Configuration, ctx *urfavecli.Context) error {
+func ParseConfig(configPath string, config *Configuration, ctx *cli.Context) error {
 	koanfInstance := koanf.New(".")
 
 	// Load file
@@ -36,7 +36,7 @@ func ParseConfig(configPath string, config *Configuration, ctx *urfavecli.Contex
 	}
 
 	// CLI flags
-	if err := koanfInstance.Load(cli.Provider(ctx, "-", koanfInstance), nil); err != nil {
+	if err := koanfInstance.Load(flag.Provider(ctx, "-", koanfInstance), nil); err != nil {
 		return err
 	}
 

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -22,6 +22,13 @@ type (
 		// 1 basically means that jobs are run in sequence.
 		// If this number is 2 or greater, then the logs are buffered and only displayed in case of errors.
 		Jobs int `json:"jobs" koanf:"jobs"`
+		// Include is a regex filter that includes repositories only when they match.
+		// The filter is applied to the whole URL.
+		// This option is not configurable in `greposync.yml`.
+		Include string `json:"-" koanf:"include"`
+		// Exclude is similar to Include, only that matching repository URLs are skipped.
+		// This option is not configurable in `greposync.yml`.
+		Exclude string `json:"-" koanf:"exclude"`
 	}
 
 	// LogConfig configures the logging options

--- a/docs/config-templates/receivers.gtpl
+++ b/docs/config-templates/receivers.gtpl
@@ -1,0 +1,1 @@
+{{/* Do not render receivers */}}

--- a/docs/modules/ROOT/pages/references/godoc.adoc
+++ b/docs/modules/ROOT/pages/references/godoc.adoc
@@ -36,15 +36,6 @@ type Configuration struct {
 
 
 
-==== Receivers
-
-===== Sanitize
-[source, go]
-----
-func (config *Configuration) Sanitize()
-----
-
-Sanitize does corrective actions on the configuration hierarchy.
 
 
 
@@ -54,6 +45,8 @@ Sanitize does corrective actions on the configuration hierarchy.
 type ProjectConfig struct {
     RootDir    string
     Jobs       int
+    Include    string
+    Exclude    string
 }
 ----
 
@@ -66,6 +59,15 @@ Jobs is the number of parallel jobs to run.
 Requires a minimum of 1, supports a maximum of 8.
 1 basically means that jobs are run in sequence.
 If this number is 2 or greater, then the logs are buffered and only displayed in case of errors.
+
+Include::
+Include is a regex filter that includes repositories only when they match.
+The filter is applied to the whole URL.
+This option is not configurable in `greposync.yml`.
+
+Exclude::
+Exclude is similar to Include, only that matching repository URLs are skipped.
+This option is not configurable in `greposync.yml`.
 
 
 
@@ -219,60 +221,6 @@ RootDir::
 RootDir is the path relative to the current workdir where the template files are located.
 
 
-
-
-
-
-
-= package cli
-
-
-
-[source,yaml]
-----
-include::example$config.yaml[]
-----
-
-== Structs
-
-=== Cli
-[source, go]
-----
-type Cli struct {
-}
-----
-
-Cli implements a urfave/cli command line provider.
-
-
-
-
-
-==== Receivers
-
-===== Read
-[source, go]
-----
-func (p *Cli) Read() (map[string]interface{}, error)
-----
-
-Read reads the flag variables and returns a nested conf map.
-
-===== ReadBytes
-[source, go]
-----
-func (p *Cli) ReadBytes() ([]byte, error)
-----
-
-ReadBytes is not supported.
-
-===== Watch
-[source, go]
-----
-func (p *Cli) Watch(cb func(event interface{}, err error)) error
-----
-
-Watch is not supported.
 
 
 

--- a/flag/provider.go
+++ b/flag/provider.go
@@ -1,4 +1,4 @@
-package cli
+package flag
 
 import (
 	"errors"

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Regex(t *testing.T) {
+	tests := map[string]struct {
+		givenIncludeRegex string
+		givenExcludeRegex string
+		expectedErr       bool
+		expectedSkip      bool
+	}{
+		"GivenEmptyRegex_WhenMatching_ThenReturnFalse": {},
+		"GivenInvalidRegex_WhenCompiling_ExpectError": {
+			givenIncludeRegex: "/\\",
+			expectedErr:       true,
+		},
+		"GivenIncludeRegex_WhenMatching_ThenReturnFalse": {
+			givenIncludeRegex: "repository",
+		},
+		"GivenExcludeRegex_WhenMatching_ThenReturnTrue": {
+			givenExcludeRegex: "repository",
+			expectedSkip:      true,
+		},
+		"GivenExcludeAndIncludeRegex_WhenMatching_ThenReturnTrue": {
+			givenIncludeRegex: "repository",
+			givenExcludeRegex: "repository",
+			expectedSkip:      true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ir, er, err := compileRegex(tt.givenIncludeRegex, tt.givenExcludeRegex)
+			if tt.expectedErr {
+				require.Error(t, err)
+				return
+			}
+			u, err := url.Parse("github.com/namespace/repository")
+			require.NoError(t, err)
+			result := skipRepository(u, ir, er)
+			assert.Equal(t, tt.expectedSkip, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

* Adds flag `--project-include`. This allows to only select a few repositories from the `managed_repos.yml`.
* Adds flag `--project-exclude`. This allows to skip selected repositories matching the regex.

Closes #34 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
