### PR TITLE
Support deletion of obsolete files in repositories and apply values for directories

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -171,6 +171,7 @@ func (c *UpdateCommand) createPipeline(r *repository.Service) *pipeline.Pipeline
 			predicate.ToStep("pull", r.Pull(), r.EnabledReset()),
 		).AsNestedStep("prepare workspace"),
 		pipeline.NewStep("render templates", renderer.RenderTemplateDir()),
+		pipeline.NewStep("cleanup unwanted files", renderer.DeleteUnwantedFiles()),
 		predicate.WrapIn(pipeline.NewPipelineWithLogger(logger).WithSteps(
 			pipeline.NewStep("add", r.Add()),
 			pipeline.NewStep("commit", r.Commit()),

--- a/docs/modules/ROOT/pages/references/sync-config.adoc
+++ b/docs/modules/ROOT/pages/references/sync-config.adoc
@@ -73,6 +73,13 @@ If this flag is set, the target file is not modified.
 
 TIP: Use this flag in `.sync.yml` if a repository maintains its own version of the file outside of {page-component-name}.
 
+`targetPath: <path>`::
+This property can override where the templated file is actually being written to.
+It is relative to the Git root directory.
+
+If the path contains the suffix `/`, the directory is changed but the file name is kept.
+Any parent directories are created as needed, with `0775` permission flags (before `umask`).
+
 .Special values usage
 [example]
 ====
@@ -84,7 +91,11 @@ TIP: Use this flag in `.sync.yml` if a repository maintains its own version of t
 
 Makefile:
   delete: true <2>
+
+subdir/.gitignore:
+  targetPath: newDir/ <3>
 ----
 <1> The repository keeps its own version of `.editorconfig`.
 <2> The repository does not need a `Makefile`.
+<3> Parse the template in `subdir/.gitignore`, but write the output to `newDir/.gitignore` in the repository root.
 ====

--- a/docs/modules/ROOT/pages/references/sync-config.adoc
+++ b/docs/modules/ROOT/pages/references/sync-config.adoc
@@ -8,10 +8,10 @@ The following hierarchy of merging and inheriting values is applied.
 The last element in the list is overwriting anything defined before.
 
 . `:globals` in `{global-defaults}`
-. `directory` in `{global-defaults}`
+. `directory/` in `{global-defaults}`
 . `directory/filename` in `{global-defaults}`
 . `:globals` in `{sync-yml}`
-. `directory` in `{sync-yml}`
+. `directory/` in `{sync-yml}`
 . `directory/filename` in `{sync-yml}`
 
 .Value hierarchy
@@ -23,10 +23,10 @@ The last element in the list is overwriting anything defined before.
 :globals:
   key: 1
 
-dir:
+dir/:
   key: 2 <1>
 
-dir/subdir:
+dir/subdir/:
   key: 3
 
 dir/subdir/file:
@@ -39,7 +39,7 @@ dir/subdir/file:
 :globals:
   key: 4
 
-dir/subdir:
+dir/subdir/:
   key: 5
 
 dir/subdir/file:
@@ -47,6 +47,13 @@ dir/subdir/file:
 ----
 <1> Any file within `dir` would get the value `key=2` as there is no override in `{sync-yml}`.
 <2> The `dir/subdir/file` would get the value `key=b` since it's overriding the key in `{global-defaults}`.
+====
+
+[NOTE]
+====
+* Specifying `/` as the top dir to apply values is not supported.
+  Use `:globals` for that purpose.
+* Appending the `/` suffix to a directory is necessary, otherwise they are interpreted as files.
 ====
 
 == Special values

--- a/rendering/config.go
+++ b/rendering/config.go
@@ -37,6 +37,10 @@ func (r *Renderer) loadDataForFile(fileName string) (Values, error) {
 	// Load the top-dir first (if any), then subdirs, then file-specific variables into values
 	for _, segment := range segments {
 		filePath = path.Join(filePath, segment)
+		// Values applicable for directories are in the form of "my-dir/", otherwise they could be files.
+		if filePath != fileName {
+			filePath += string(filepath.Separator)
+		}
 		err = r.k.Unmarshal(filePath, &data)
 		if err != nil {
 			return data, err

--- a/rendering/config_test.go
+++ b/rendering/config_test.go
@@ -78,7 +78,7 @@ func TestRenderer_loadDataForFile(t *testing.T) {
 			givenFileName: "subdir/README.md",
 			givenValues: Values{
 				":globals": Values{"key": "variable"},
-				"subdir": Values{
+				"subdir/": Values{
 					"intermediate": "value",
 				},
 				"subdir/README.md": Values{
@@ -89,17 +89,36 @@ func TestRenderer_loadDataForFile(t *testing.T) {
 			expectedValues: Values{
 				"key": Values{
 					"nested": "key"},
-				"intermediate": "value"},
+				"intermediate": "value",
+			},
+		},
+		"GivenSubDirectoryInWrongSyntax_WhenBuildingVarsForFile_ThenIgnoreInvalidValues": {
+			givenFileName: "subdir/README.md",
+			givenValues: Values{
+				":globals": Values{"key": "variable"},
+				"subdir": Values{
+					"intermediate": "value",
+				},
+				"subdir/README.md": Values{
+					"key": Values{
+						"nested": "key",
+					}},
+			},
+			expectedValues: Values{
+				"key": Values{
+					"nested": "key",
+				},
+			},
 		},
 		"GivenMultipleSubDirectories_WhenBuildingVarsForFile_ThenMergeSubDirectoryValues": {
 			givenFileName: "subdir1/subdir2/README.md",
 			givenValues: Values{
 				":globals": Values{"key": "variable"},
-				"subdir1": Values{
+				"subdir1/": Values{
 					"intermediate1": "foo",
 					"override":      "to-be-overridden",
 				},
-				"subdir1/subdir2": Values{
+				"subdir1/subdir2/": Values{
 					"intermediate2": "bar",
 					"override":      "inherited",
 				},

--- a/rendering/delete.go
+++ b/rendering/delete.go
@@ -1,0 +1,61 @@
+package rendering
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	pipeline "github.com/ccremer/go-command-pipeline"
+)
+
+// DeleteUnwantedFiles goes through the sync config and deletes files from repositories that aren't targeted by the templates.
+// The config need to have the `delete` flag set to true.
+// Only files are deleted, not directories.
+func (r *Renderer) DeleteUnwantedFiles() pipeline.ActionFunc {
+	return func() pipeline.Result {
+		files := r.searchOrphanedFiles()
+		for _, relativePath := range files {
+			targetPath := path.Clean(path.Join(r.cfg.Git.Dir, relativePath))
+			err := r.deleteFileIfExists(targetPath)
+			if err != nil {
+				return pipeline.Result{Err: err}
+			}
+		}
+		return pipeline.Result{}
+	}
+}
+
+func (r *Renderer) searchOrphanedFiles() []string {
+	filePaths := make([]string, 0)
+	allKeys := r.k.Raw()
+	// Go through all top-level keys, which are the file names
+	for filePath, values := range allKeys {
+		// If the filename is already handled by the template renderer, ignore it.
+		// Otherwise, add files that have deletion flag, but ignore directories
+		if _, found := r.parser.templates[filePath]; !found && pathIsFile(filePath) {
+			if val, ok := values.(map[string]interface{}); ok {
+				if filePath == ":globals" {
+					// can't delete file named ':globals' anyway
+					continue
+				}
+				if val["delete"] == true {
+					filePaths = append(filePaths, filePath)
+				}
+			}
+		}
+	}
+	return filePaths
+}
+
+func pathIsFile(filePath string) bool {
+	return !strings.HasSuffix(filePath, string(filepath.Separator))
+}
+
+func (r *Renderer) deleteFileIfExists(targetPath string) error {
+	if fileExists(targetPath) {
+		r.p.InfoF("Deleting file due to 'delete' flag being set: %s", targetPath)
+		return os.Remove(targetPath)
+	}
+	return nil
+}

--- a/rendering/delete_test.go
+++ b/rendering/delete_test.go
@@ -1,0 +1,82 @@
+package rendering
+
+import (
+	"path"
+	"testing"
+	"text/template"
+
+	"github.com/ccremer/greposync/cfg"
+	"github.com/ccremer/greposync/printer"
+	"github.com/knadh/koanf"
+	"github.com/knadh/koanf/providers/confmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderer_searchOrphanedFiles(t *testing.T) {
+	tests := map[string]struct {
+		givenValues       Values
+		expectedFileNames []string
+	}{
+		"GivenExistingTemplateName_WhenSearching_ThenIgnore": {
+			givenValues: Values{
+				"Readme.md": map[string]interface{}{
+					"delete": true,
+				},
+			},
+			expectedFileNames: []string{},
+		},
+		"GivenNoMatchingTemplate_WhenSearching_ThenReturnOrphanedKeys": {
+			givenValues: Values{
+				".gitignore": map[string]interface{}{
+					"delete": true,
+				},
+			},
+			expectedFileNames: []string{".gitignore"},
+		},
+		"GivenDirectoriesInKeys_WhenSearching_ThenIgnoreDirectories": {
+			givenValues: Values{
+				"dir/": map[string]interface{}{
+					"delete": true,
+				},
+				"dir/filename": map[string]interface{}{
+					"delete": true,
+				},
+			},
+			expectedFileNames: []string{"dir/filename"},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			r := &Renderer{
+				k: koanf.New(""),
+				parser: &Parser{templates: map[string]*template.Template{
+					"Readme.md": nil,
+				}},
+			}
+			require.NoError(t, r.k.Load(confmap.Provider(tt.givenValues, ""), nil))
+			files := r.searchOrphanedFiles()
+			assert.Equal(t, tt.expectedFileNames, files)
+		})
+	}
+}
+
+func (s *TemplateTestSuite) TestDeleteUnwantedFiles() {
+	r := &Renderer{
+		k:      koanf.New(""),
+		parser: &Parser{templates: map[string]*template.Template{}},
+		cfg: &cfg.SyncConfig{
+			Git: &cfg.GitConfig{
+				Dir: s.SeedTargetDir,
+			},
+		},
+		p: printer.New(),
+	}
+	s.Require().NoError(r.k.Load(confmap.Provider(Values{
+		"readme.md": map[string]interface{}{
+			"delete": true,
+		},
+	}, ""), nil))
+	r.DeleteUnwantedFiles()()
+	s.Assert().NoFileExists(path.Join(s.SeedTargetDir, "readme.md"))
+}

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -92,6 +92,16 @@ func (r *Renderer) applyTemplate(targetPath string, tpl *template.Template, valu
 		r.p.DebugF("Leaving file alone due to 'unmanaged' flag being set: %s", targetPath)
 		return nil
 	}
+	if newTarget := values["Values"].(Values)["targetPath"]; newTarget != nil && newTarget != "" {
+		newPath := newTarget.(string)
+		if strings.HasSuffix(newPath, string(filepath.Separator)) {
+			newPath = path.Clean(path.Join(r.cfg.Git.Dir, newPath, path.Base(targetPath)))
+		} else {
+			newPath = path.Clean(path.Join(r.cfg.Git.Dir, newPath))
+		}
+		r.p.DebugF("Redefining target path from '%s' to '%s", targetPath, newPath)
+		targetPath = newPath
+	}
 	return r.writeFile(targetPath, tpl, values)
 }
 

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -82,14 +82,10 @@ func (r *Renderer) processTemplate(originalTemplatePath string, tpl *template.Te
 
 func (r *Renderer) applyTemplate(targetPath string, tpl *template.Template, values Values) error {
 	if values["Values"].(Values)["delete"] == true {
-		if fileExists(targetPath) {
-			r.p.DebugF("Deleting file due to 'delete' flag being set: %s", targetPath)
-			return os.Remove(targetPath)
-		}
-		return nil
+		return r.deleteFileIfExists(targetPath)
 	}
 	if values["Values"].(Values)["unmanaged"] == true {
-		r.p.DebugF("Leaving file alone due to 'unmanaged' flag being set: %s", targetPath)
+		r.p.InfoF("Leaving file alone due to 'unmanaged' flag being set: %s", targetPath)
 		return nil
 	}
 	if newTarget := values["Values"].(Values)["targetPath"]; newTarget != nil && newTarget != "" {


### PR DESCRIPTION
## Summary

* NEW SYNTAX: The feature introduced in #40 has a slightly changed syntax. From now on, values that are applied for directories require the `/` suffix in the key. This is to distinguish them from files.
* NEW SYNTAX: There is a new special value `targetPath`: It allows to alter the relative filename that is coming from the template dir. This allows moving files before writing them, e.g. `targetPath=subdir/` the file is moved from `template/.gitignore` -> `repo/subdir/.gitignore`
* Further enhances the `delete=true` special value. Previously, only files for which there was also a template were deleted if this flag is set. Now it iterates over each file in the sync config that have also have this flag, and remove them if not done already. This allows to delete obsolete files from all repositories.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
