### PR TITLE
Add 'init' sub command

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -54,12 +54,14 @@ func CreateCLI(version, commit, date string) {
 		},
 	}
 	updateCommand := NewUpdateCommand(config)
+	initCommand := NewInitCommand()
 	app = &cli.App{
 		Name:                 "greposync",
 		Usage:                "git-repo-sync: Shameless reimplementation of ModuleSync in Go",
 		Version:              fmt.Sprintf("%s, commit %s, date %s", version, commit[0:7], t.Format(dateLayout)),
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
+			initCommand.createInitCommand(),
 			updateCommand.createUpdateCommand(),
 		},
 		Compiled: t,

--- a/cli/init.go
+++ b/cli/init.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	pipeline "github.com/ccremer/go-command-pipeline"
+	"github.com/ccremer/greposync/cfg"
+	"github.com/ccremer/greposync/cli/initialize"
+	"github.com/ccremer/greposync/printer"
+	"github.com/urfave/cli/v2"
+)
+
+type (
+	// InitCommand contains the logic to initialize a new template repository.
+	InitCommand struct {
+		cfg        *cfg.Configuration
+		cliCommand *cli.Command
+	}
+)
+
+// NewInitCommand returns a new instance.
+func NewInitCommand() *InitCommand {
+	return &InitCommand{}
+}
+
+func (c *InitCommand) createInitCommand() *cli.Command {
+	c.cliCommand = &cli.Command{
+		Name:   "init",
+		Usage:  "Initializes a template repository in the current working directory",
+		Action: c.runInitCommand,
+	}
+	return c.cliCommand
+}
+
+func (c *InitCommand) runInitCommand(_ *cli.Context) error {
+	logger := printer.PipelineLogger{Logger: printer.New().SetLevel(printer.DefaultLevel)}
+	result := pipeline.NewPipelineWithLogger(logger).WithSteps(
+		pipeline.NewStep("create main config files", initialize.CreateMainConfigFiles()),
+		pipeline.NewStep("create template dir", initialize.CreateTemplateDir()),
+		pipeline.NewStep("create template files", initialize.CreateTemplateFiles()),
+	).Run()
+	return result.Err
+}

--- a/cli/initialize/README.adoc.tpl
+++ b/cli/initialize/README.adoc.tpl
@@ -1,0 +1,5 @@
+{{- template "comment" . -}}
+
+= {{ .Values.name }}
+
+{{ .Values.description }}

--- a/cli/initialize/_helpers.tpl
+++ b/cli/initialize/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "comment" -}}
+{{ .Values.comment | replace "# " (default "# " .Values.commentPrefix) }}
+{{- end }}

--- a/cli/initialize/config_defaults.yml
+++ b/cli/initialize/config_defaults.yml
@@ -1,0 +1,13 @@
+# This is the config file for greposync that defines default values
+# Visit the documentation at https://ccremer.github.io/greposync
+
+:globals:
+  name: my-repository
+  comment: |
+    # This file is managed by greposync.
+    # Do not modify manually.
+    # Adjust variables in `.sync.yml`.
+
+README.adoc:
+  description: My awesome, greposync managed repository
+  commentPrefix: "// "

--- a/cli/initialize/files.go
+++ b/cli/initialize/files.go
@@ -1,0 +1,93 @@
+package initialize
+
+import (
+	_ "embed"
+	"os"
+
+	pipeline "github.com/ccremer/go-command-pipeline"
+)
+
+var (
+	//go:embed _helpers.tpl
+	helperTpl []byte
+	//go:embed README.adoc.tpl
+	readmeTpl []byte
+
+	//go:embed greposync.yml
+	grepoSyncYml []byte
+	//go:embed config_defaults.yml
+	configDefaultsYml []byte
+	//go:embed managed_repos.yml
+	managedReposYml []byte
+
+	configFiles = map[string][]byte{
+		"greposync.yml":       grepoSyncYml,
+		"config_defaults.yml": configDefaultsYml,
+		"managed_repos.yml":   managedReposYml,
+	}
+	templateFiles = map[string][]byte{
+		"template/_helpers.tpl": helperTpl,
+		"template/README.adoc":  readmeTpl,
+	}
+)
+
+// CreateMainConfigFiles creates the main configuration files.
+// Each pre existing file is skipped.
+func CreateMainConfigFiles() pipeline.ActionFunc {
+	return func() pipeline.Result {
+		return pipeline.Result{Err: writeFiles(configFiles)}
+	}
+}
+
+// CreateTemplateFiles creates the example files in the template directory.
+// The dir has to exist.
+func CreateTemplateFiles() pipeline.ActionFunc {
+	return func() pipeline.Result {
+		return pipeline.Result{Err: writeFiles(templateFiles)}
+	}
+}
+
+func writeFiles(files map[string][]byte) error {
+	for file, content := range files {
+		err := writeFile(file, content)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeFile(file string, content []byte) error {
+	if !fileExists(file) {
+		return os.WriteFile(file, content, 0644)
+	}
+	return nil
+}
+
+// CreateTemplateDir creates the template directory if it doesn't exist.
+func CreateTemplateDir() pipeline.ActionFunc {
+	return func() pipeline.Result {
+		return pipeline.Result{Err: createDir("template")}
+	}
+}
+
+func fileExists(path string) bool {
+	if f, err := os.Stat(path); err == nil && !f.IsDir() {
+		return true
+	}
+	return false
+}
+
+func dirExists(path string) bool {
+	if f, err := os.Stat(path); err == nil && f.IsDir() {
+		return true
+	}
+	return false
+}
+
+func createDir(path string) error {
+	if !dirExists(path) {
+		return os.Mkdir(path, 0775)
+	}
+	return nil
+}

--- a/cli/initialize/files_test.go
+++ b/cli/initialize/files_test.go
@@ -1,0 +1,103 @@
+package initialize
+
+import (
+	"os"
+	"testing"
+
+	"github.com/ccremer/greposync/cfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+)
+
+func Test_ParseGreposyncYaml(t *testing.T) {
+	bytes, err := os.ReadFile("greposync.yml")
+	require.NoError(t, err)
+	config := &cfg.Configuration{}
+	err = yaml.Unmarshal(bytes, config)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"greposync"}, config.PullRequest.Labels)
+	assert.False(t, config.PullRequest.Create)
+	assert.Equal(t, "Update from greposync", config.PullRequest.Subject)
+}
+
+func Test_createDir(t *testing.T) {
+	tests := map[string]struct {
+		givenDir  string
+		expectErr bool
+	}{
+		"GivenNonExistingDirectory_WhenCreating_ThenCreateDirectory": {
+			givenDir: "testdir",
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := createDir(tt.givenDir)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.DirExists(t, tt.givenDir)
+			defer require.NoError(t, os.Remove(tt.givenDir))
+		})
+	}
+}
+
+func Test_writeFile(t *testing.T) {
+	tests := map[string]struct {
+		givenFilename string
+		givenContent  string
+		expectErr     bool
+	}{
+		"GivenNonExistingFile_WhenWriting_ThenCreateFileWithContent": {
+			givenFilename: "test_file",
+			givenContent:  "test content",
+		},
+		"GivenInvalidFileName_WhenWriting_ThenExpectError": {
+			givenFilename: "invalid/",
+			expectErr:     true,
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := writeFile(tt.givenFilename, []byte(tt.givenContent))
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			result, readErr := os.ReadFile(tt.givenFilename)
+			defer require.NoError(t, os.Remove(tt.givenFilename))
+			require.NoError(t, readErr)
+			assert.Equal(t, []byte(tt.givenContent), result)
+		})
+	}
+}
+
+func Test_writeFiles(t *testing.T) {
+	tests := map[string]struct {
+		givenFiles map[string][]byte
+		expectErr  bool
+	}{
+		"GivenNonExistingFiles_WhenWriting_ThenCreateFile": {
+			givenFiles: map[string][]byte{
+				"test_file": []byte("content"),
+			},
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := writeFiles(tt.givenFiles)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			for file, _ := range tt.givenFiles {
+				assert.FileExists(t, file)
+				require.NoError(t, os.Remove(file))
+			}
+		})
+	}
+}

--- a/cli/initialize/greposync.yml
+++ b/cli/initialize/greposync.yml
@@ -1,0 +1,21 @@
+# This is the main config file for greposync
+# Visit the documentation at https://ccremer.github.io/greposync
+
+git:
+  # Branch name in which to make commits
+  commitBranch: greposync
+  # Commit message when updating a repository
+  commitMessage: Update from greposync
+  # Whether to use force-push. Required when using --amend
+  forcePush: false
+  # The default owner or organization name
+  namespace: ""
+pr:
+  bodyTemplate: This Pull request updates this repository with changes from a greposync template repository.
+  # Enable this flag to create and update pull requests
+  create: false
+  # Labels to attach to the pull request
+  labels:
+  - greposync
+  subject: Update from greposync
+  targetBranch: ""

--- a/cli/initialize/managed_repos.yml
+++ b/cli/initialize/managed_repos.yml
@@ -1,0 +1,5 @@
+# This is the config file that lists managed Git repositories for greposync
+# Visit the documentation at https://ccremer.github.io/greposync
+
+repositories:
+  - name: my-repository

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,6 +2,7 @@
 * https://github.com/ccremer/greposync/releases[Changelog,window=_blank]
 
 .Tutorials
+* xref:tutorials/getting-started.adoc[Getting started]
 
 .How To
 * xref:how-tos/inherit-value.adoc[Inherit values in directories]

--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -1,0 +1,69 @@
+= Getting started
+:control-repo: greposync-control
+:managed-repo: my-repository
+
+🏁 Goals::
+. Set up a template repository
+. Onboard a managed repository
+. Commit the changes
+
+== Prerequisites
+
+NOTE: Currently, only Linux is supported.
+
+You need the following tools installed in your `$PATH`.
+
+* `git`
+* `gsync`
+* `editor` (Your favorite text editor)
+
+Additionally, you need the following.
+
+* A user account on github.com
+* https://github.com/settings/keys[SSH key] associated with your GitHub account.
+  See https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh[this article] if you need help.
+
+[NOTE]
+====
+For the purpose of this guide, following repository names are being used:
+
+- `{control-repo}`: The repository containing the config and templates.
+- `{managed-repo}`: The test repository which we are going to be managing with {page-component-title}
+====
+
+== Setup template repository
+
+In the first step, we're going to initialize a Git repository that contains the template.
+
+. Create a new repository called `{control-repo}` in https://github.com/new[GitHub]
+
+. Clone the new repository
++
+[source,bash]
+----
+git clone <git-url>
+----
+
+. Initialize {page-component-name}
++
+[source,bash,subs="attributes+"]
+----
+cd {control-repo}
+gsync init
+----
+
+And that's it!
+You should now see a structure similar to the following:
+
+[source,console,subs="attributes+"]
+----
+{control-repo}
+├── config_defaults.yml
+├── greposync.yml
+├── managed_repos.yml
+└── template
+    ├── _helpers.tpl
+    └── README.adoc
+----
+
+// There is more to come here!

--- a/generate.go
+++ b/generate.go
@@ -15,11 +15,19 @@ import (
 )
 
 func main() {
-	config := cfg.NewDefaultConfig()
+	createExampleConfig()
+}
 
-	bytes, err := yaml.Marshal(config)
+func createExampleConfig() {
+	exampleConfig := cfg.NewDefaultConfig()
+
+	bytes, err := yaml.Marshal(exampleConfig)
 	exit(err)
-	exit(ioutil.WriteFile(os.Getenv("GODOC_YAML_DEFAULTS_PATH"), bytes, 0775))
+	writeFile(os.Getenv("GODOC_YAML_DEFAULTS_PATH"), bytes)
+}
+
+func writeFile(path string, bytes []byte) {
+	exit(ioutil.WriteFile(path, bytes, 0775))
 }
 
 func exit(err error) {


### PR DESCRIPTION
## Summary

* Adds `greposync init` command that sets up example config files and template to help getting started.
* The files are created in the current dir.
* Adds a tutorial page

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
