### PR TITLE
Don't show diff if there is no previous commit available

### DIFF
--- a/repository/diff.go
+++ b/repository/diff.go
@@ -12,6 +12,10 @@ func (s *Service) Diff() pipeline.ActionFunc {
 	return func() pipeline.Result {
 		out, stderr, err := s.execGitCommand(s.logArgs("diff", "HEAD~1")...)
 		if err != nil {
+			if strings.Contains(stderr, "ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.") {
+				s.p.InfoF("This is the first commit, no diff available.")
+				return pipeline.Result{}
+			}
 			return s.toResult(err, stderr)
 		}
 		s.prettyPrint(out)


### PR DESCRIPTION
## Summary

* Fix diff if there is no previous commit available

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
