### PR TITLE
Fix force-push and push even if nothing comitted

### DIFF
--- a/cli/update.go
+++ b/cli/update.go
@@ -176,8 +176,8 @@ func (c *UpdateCommand) createPipeline(r *repository.Service) *pipeline.Pipeline
 			pipeline.NewStep("add", r.Add()),
 			pipeline.NewStep("commit", r.Commit()),
 			pipeline.NewStep("show diff", r.Diff()),
-			predicate.ToStep("push", r.PushToRemote(), r.EnabledPush()),
-		).AsNestedStep("push changes"), predicate.And(r.EnabledCommit(), r.Dirty())),
+		).AsNestedStep("commit changes"), predicate.And(r.EnabledCommit(), r.Dirty())),
+		predicate.ToStep("push changes", r.PushToRemote(), r.EnabledPush()),
 		predicate.WrapIn(pipeline.NewPipelineWithLogger(logger).WithSteps(
 			pipeline.NewStep("render pull request template", renderer.RenderPrTemplate()),
 			pipeline.NewStep("create or update pull request", r.CreateOrUpdatePr(config.PullRequest)),

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -65,7 +65,7 @@ func NewServicesFromFile(config *cfg.Configuration) ([]*Service, error) {
 			Config: &cfg.GitConfig{
 				Dir:           path.Clean(path.Join(config.Project.RootDir, strings.ReplaceAll(u.Hostname(), ":", "-"), u.Path)),
 				Url:           u,
-				ForcePush:     true,
+				ForcePush:     config.Git.ForcePush,
 				SkipReset:     config.Git.SkipReset,
 				SkipPush:      config.Git.SkipPush,
 				SkipCommit:    config.Git.SkipCommit,


### PR DESCRIPTION
## Summary

* Fix force-push flag that is always applied even when set to false in the config
* Push to remote even if there was nothing to commit. There could be cases where --dry-run=commit ran, but a second run with --dry-run=push wouldn't push it to remote, since there was nothing to commit.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
