### PR TITLE
Update comment helper in init template

### DIFF
--- a/cli/initialize/README.md.tpl
+++ b/cli/initialize/README.md.tpl
@@ -1,5 +1,5 @@
 {{- template "comment" . -}}
 
-= {{ .Values.name }}
+# {{ .Values.name }}
 
 {{ .Values.description }}

--- a/cli/initialize/_helpers.tpl
+++ b/cli/initialize/_helpers.tpl
@@ -1,3 +1,13 @@
 {{- define "comment" -}}
-{{ .Values.comment | replace "# " (default "# " .Values.commentPrefix) }}
-{{- end }}
+{{- if .Values.comment.text }}
+{{- with .Values.comment.open -}}
+{{ . }}
+{{ end -}}
+{{- with .Values.comment.text -}}
+{{ $.Values.comment.prefix }}{{ . | splitList "\n" | join (cat "\n" $.Values.comment.prefix | replace "\n " "\n") }}
+{{ end }}
+{{- with .Values.comment.closed -}}
+{{ . }}
+{{ end -}}
+{{- end -}}
+{{- end -}}

--- a/cli/initialize/config_defaults.yml
+++ b/cli/initialize/config_defaults.yml
@@ -3,11 +3,14 @@
 
 :globals:
   name: my-repository
-  comment: |
-    # This file is managed by greposync.
-    # Do not modify manually.
-    # Adjust variables in `.sync.yml`.
+  comment:
+    text: |
+      This file is managed by greposync.
+      Do not modify manually.
+      Adjust variables in `.sync.yml`.
+    prefix: ""
+    open: <!--
+    closed: -->
 
-README.adoc:
+README.md:
   description: My awesome, greposync managed repository
-  commentPrefix: "// "

--- a/cli/initialize/files.go
+++ b/cli/initialize/files.go
@@ -10,7 +10,7 @@ import (
 var (
 	//go:embed _helpers.tpl
 	helperTpl []byte
-	//go:embed README.adoc.tpl
+	//go:embed README.md.tpl
 	readmeTpl []byte
 
 	//go:embed greposync.yml
@@ -27,7 +27,7 @@ var (
 	}
 	templateFiles = map[string][]byte{
 		"template/_helpers.tpl": helperTpl,
-		"template/README.adoc":  readmeTpl,
+		"template/README.md":    readmeTpl,
 	}
 )
 

--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -61,7 +61,7 @@ You should now see a structure similar to the following:
 ├── managed_repos.yml
 └── template
     ├── _helpers.tpl
-    └── README.adoc
+    └── README.md
 ----
 
 // There is more to come here!


### PR DESCRIPTION
## Summary

* Renames README.adoc to README.md (using GitHub flavored Markdown to enable comments)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
