### PR TITLE
Add 'labels' subcommand to sync all issue labels

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -36,7 +36,7 @@ func ParseConfig(configPath string, config *Configuration, ctx *cli.Context) err
 	}
 
 	// CLI flags
-	if err := koanfInstance.Load(flag.Provider(ctx, "-", koanfInstance, "."), nil); err != nil {
+	if err := koanfInstance.Load(flag.Provider(ctx, "-", koanfInstance), nil); err != nil {
 		return err
 	}
 

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -7,11 +7,12 @@ import (
 type (
 	// Configuration holds a strongly-typed tree of the main configuration
 	Configuration struct {
-		Project     *ProjectConfig     `json:"project" koanf:"project"`
-		Log         *LogConfig         `json:"log" koanf:"log"`
-		PullRequest *PullRequestConfig `json:"pr" koanf:"pr"`
-		Template    *TemplateConfig    `json:"template" koanf:"template"`
-		Git         *GitConfig         `json:"git" koanf:"git"`
+		Project          *ProjectConfig             `json:"project" koanf:"project"`
+		Log              *LogConfig                 `json:"log" koanf:"log"`
+		PullRequest      *PullRequestConfig         `json:"pr" koanf:"pr"`
+		Template         *TemplateConfig            `json:"template" koanf:"template"`
+		Git              *GitConfig                 `json:"git" koanf:"git"`
+		RepositoryLabels map[string]RepositoryLabel `json:"repositoryLabels" koanf:"repositoryLabels"`
 	}
 	// ProjectConfig configures the project
 	ProjectConfig struct {
@@ -52,6 +53,17 @@ type (
 		BodyTemplate string `json:"bodyTemplate" koanf:"bodyTemplate"`
 		// Subject is the Pull Request title.
 		Subject string `json:"subject" koanf:"subject"`
+	}
+	// RepositoryLabel is a struct describing a Label on a Git hosting service like GitHub.
+	RepositoryLabel struct {
+		// Name is the label name.
+		Name string `json:"name" koanf:"name"`
+		// Description is a short description of the label.
+		Description string `json:"description" koanf:"description"`
+		// Color is the hexadecimal color code for the label, without the leading #.
+		Color string `json:"color" koanf:"color"`
+		// Delete will remove this label.
+		Delete bool `json:"delete" koanf:"delete"`
 	}
 
 	// SyncConfig configures a single repository sync

--- a/cli/app.go
+++ b/cli/app.go
@@ -53,16 +53,15 @@ func CreateCLI(version, commit, date string) {
 			Value:   1,
 		},
 	}
-	updateCommand := NewUpdateCommand(config)
-	initCommand := NewInitCommand()
 	app = &cli.App{
 		Name:                 "greposync",
 		Usage:                "git-repo-sync: Shameless reimplementation of ModuleSync in Go",
 		Version:              fmt.Sprintf("%s, commit %s, date %s", version, commit[0:7], t.Format(dateLayout)),
 		EnableBashCompletion: true,
 		Commands: []*cli.Command{
-			initCommand.createInitCommand(),
-			updateCommand.createUpdateCommand(),
+			NewInitCommand().createInitCommand(),
+			NewUpdateCommand(config).createUpdateCommand(),
+			NewLabelsCommand(config).createCommand(),
 		},
 		Compiled: t,
 		ExitErrHandler: func(context *cli.Context, err error) {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -1,0 +1,19 @@
+package cli
+
+import "github.com/urfave/cli/v2"
+
+const (
+	projectIncludeFlagName = "project-include"
+	projectExcludeFlagName = "project-exclude"
+)
+
+var (
+	projectIncludeFlag = &cli.StringFlag{
+		Name:  projectIncludeFlagName,
+		Usage: "Includes only repositories in the update that match the given filter (regex).",
+	}
+	projectExcludeFlag = &cli.StringFlag{
+		Name:  projectExcludeFlagName,
+		Usage: "Excludes repositories from updating that match the given filter (regex). Repositories matching both include and exclude filter are still excluded.",
+	}
+)

--- a/cli/labels.go
+++ b/cli/labels.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	pipeline "github.com/ccremer/go-command-pipeline"
+	"github.com/ccremer/go-command-pipeline/parallel"
+	"github.com/ccremer/greposync/cfg"
+	"github.com/ccremer/greposync/printer"
+	"github.com/ccremer/greposync/repository"
+	"github.com/hashicorp/go-multierror"
+	"github.com/urfave/cli/v2"
+)
+
+type (
+	// LabelsCommand contains the logic to keep repository labels in sync.
+	LabelsCommand struct {
+		cfg          *cfg.Configuration
+		cliCommand   *cli.Command
+		repoServices []*repository.Service
+	}
+)
+
+// NewLabelsCommand returns a new instance.
+func NewLabelsCommand(cfg *cfg.Configuration) *LabelsCommand {
+	return &LabelsCommand{
+		cfg: cfg,
+	}
+}
+
+func (c *LabelsCommand) createCommand() *cli.Command {
+	c.cliCommand = &cli.Command{
+		Name:   "labels",
+		Usage:  "Synchronizes repository labels",
+		Before: c.validateCommand,
+		Action: c.runCommand,
+		Flags:  combineWithGlobalFlags(
+		//projectIncludeFlag,
+		//projectExcludeFlag,
+		),
+	}
+	return c.cliCommand
+}
+
+func (c *LabelsCommand) validateCommand(ctx *cli.Context) error {
+	if err := cfg.ParseConfig(GrepoSyncFileName, config, ctx); err != nil {
+		return err
+	}
+
+	if err := validateGlobalFlags(ctx); err != nil {
+		return err
+	}
+
+	if _, err := regexp.Compile(config.Project.Include); err != nil {
+		return fmt.Errorf("invalid flag --%s: %v", projectIncludeFlagName, err)
+	}
+	if _, err := regexp.Compile(config.Project.Exclude); err != nil {
+		return fmt.Errorf("invalid flag --%s: %v", projectExcludeFlagName, err)
+	}
+
+	if jobs := config.Project.Jobs; jobs > JobsMaximumCount || jobs < JobsMinimumCount {
+		return fmt.Errorf("--%s is required to be between %d and %d", projectJobsFlagName, JobsMinimumCount, JobsMaximumCount)
+	}
+
+	for key, label := range config.RepositoryLabels {
+		if label.Name == "" {
+			return fmt.Errorf("label name with key '%s' cannot be empty in '%s'", key, "repositoryLabels")
+		}
+	}
+
+	config.Sanitize()
+	j, _ := json.Marshal(config)
+	printer.DebugF("Using config: %s", j)
+	return nil
+}
+
+func (c *LabelsCommand) runCommand(ctx *cli.Context) error {
+	logger := printer.PipelineLogger{Logger: printer.New().SetName(ctx.Command.Name).SetLevel(printer.DefaultLevel)}
+	result := pipeline.NewPipelineWithLogger(logger).WithSteps(
+		pipeline.NewStep("parse config", c.parseServices()),
+		parallel.NewWorkerPoolStep("update labels", config.Project.Jobs, c.updateReposInParallel(), c.errorHandler()),
+	).Run()
+	return result.Err
+}
+
+func (c *LabelsCommand) parseServices() func() pipeline.Result {
+	return func() pipeline.Result {
+		s, err := repository.NewServicesFromFile(config)
+		c.repoServices = s
+		return pipeline.Result{Err: err}
+	}
+}
+
+func (c *LabelsCommand) updateReposInParallel() parallel.PipelineSupplier {
+	return func(pipelines chan *pipeline.Pipeline) {
+		defer close(pipelines)
+		for _, r := range c.repoServices {
+			p := c.createPipeline(r)
+			pipelines <- p
+		}
+	}
+}
+
+func (c *LabelsCommand) createPipeline(r *repository.Service) *pipeline.Pipeline {
+
+	log := printer.New().SetName(r.Config.Name).SetLevel(printer.DefaultLevel)
+	logger := printer.PipelineLogger{Logger: log}
+
+	p := pipeline.NewPipelineWithLogger(logger)
+	p.WithSteps(
+		pipeline.NewStep("prepare API", r.InitializeGitHubProvider(c.cfg.PullRequest)),
+		pipeline.NewStep("update labels", r.CreateOrUpdateLabels(c.cfg.RepositoryLabels)),
+	)
+	return p
+}
+
+func (c *LabelsCommand) errorHandler() parallel.ResultHandler {
+	return func(results map[uint64]pipeline.Result) pipeline.Result {
+		var err error
+		for index, service := range c.repoServices {
+			if result := results[uint64(index)]; result.Err != nil {
+				err = multierror.Append(err, fmt.Errorf("%s: %w", service.Config.Name, result.Err))
+			}
+		}
+		return pipeline.Result{Err: err}
+	}
+}

--- a/docs/modules/ROOT/examples/config.yaml
+++ b/docs/modules/ROOT/examples/config.yaml
@@ -19,5 +19,6 @@ pr:
 project:
   jobs: 1
   rootDir: repos
+repositoryLabels: null
 template:
   rootDir: template

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -11,6 +11,7 @@
 * xref:how-tos/delete-file.adoc[Remove file in a specific repository]
 * xref:how-tos/delete-files.adoc[Remove files in all repositories]
 * xref:how-tos/comment-files.adoc[Add comment headers]
+* xref:how-tos/sync-labels.adoc[Sync labels in all repositories]
 * xref:how-tos/migrate-from-modulesync.adoc[Migrate from ModuleSync]
 
 .Technical reference

--- a/docs/modules/ROOT/pages/how-tos/sync-labels.adoc
+++ b/docs/modules/ROOT/pages/how-tos/sync-labels.adoc
@@ -1,0 +1,46 @@
+= Sync labels in all repositories
+
+❓ Question::
+I want to apply the same set of labels on all repositories.
+How do I do that?
+
+📝 Use case::
+If all repositories have the same set of label names, colors and descriptions, it will make managing those easier.
+Especially useful in cases where a changelog is being created from pull requests that are categorized by labels.
+
+'''
+
+💡 Solution::
+Prepare config to manage repository labels:
++
+.{page-component-name}.yml
+[source,yaml]
+----
+repositoryLabels:
+  greposync:
+    name: greposync <1>
+    color: FFFFFF <2>
+    description: An update by greposync
+  goodfirstissue:
+    name: good first issue
+    delete: true <3>
+----
+<1> Required property `name`
+<2> Set a hexadecimal color without leading `#`
+<3> Delete the label by the given name (`.name` is still required)
++
+[NOTE]
+====
+The names in the `repositoryLabels` are irrelevant for {page-component-name} as they are transformed into an array.
+But they may later be useful when deep merging with overrides per repository (not implemented).
+====
++
+Run the `labels` subcommand:
++
+[source,bash]
+----
+gsync labels
+----
+
+🔗 Reference::
+* xref:references/greposync.adoc[{page-component-name}.yml]

--- a/docs/modules/ROOT/pages/references/godoc.adoc
+++ b/docs/modules/ROOT/pages/references/godoc.adoc
@@ -15,13 +15,16 @@ include::example$config.yaml[]
 [source, go]
 ----
 type Configuration struct {
-    Project        *ProjectConfig
-    Log            *LogConfig
-    PullRequest    *PullRequestConfig
-    Template       *TemplateConfig
-    Git            *GitConfig
+    Project             *ProjectConfig
+    Log                 *LogConfig
+    PullRequest         *PullRequestConfig
+    Template            *TemplateConfig
+    Git                 *GitConfig
+    RepositoryLabels    map[string]RepositoryLabel
 }
 ----
+
+
 
 
 
@@ -120,6 +123,34 @@ If empty, the CommitMessage is used.
 
 Subject::
 Subject is the Pull Request title.
+
+
+
+
+
+=== RepositoryLabel
+[source, go]
+----
+type RepositoryLabel struct {
+    Name           string
+    Description    string
+    Color          string
+    Delete         bool
+}
+----
+
+
+Name::
+Name is the label name.
+
+Description::
+Description is a short description of the label.
+
+Color::
+Color is the hexadecimal color code for the label, without the leading #.
+
+Delete::
+Delete will remove this label.
 
 
 

--- a/flag/provider.go
+++ b/flag/provider.go
@@ -11,10 +11,9 @@ import (
 
 // Cli implements a urfave/cli command line provider.
 type Cli struct {
-	delim   string
-	koDelim string
-	ko      *koanf.Koanf
-	ctx     *cli.Context
+	delim string
+	ko    *koanf.Koanf
+	ctx   *cli.Context
 }
 
 /*
@@ -23,14 +22,12 @@ For instance, the flagDelim "." will convert the flag name `parent.child.key: 1`
 It takes an optional (but recommended) Koanf instance to see if the the flags defined have been set from other providers, for instance, a config file.
 If they are not, then the default values of the flags are merged.
 If they do exist, the flag values are not merged but only the values that have been explicitly set in the command line are merged.
-koDelim is the delimiter passed to ko (if non-nil) and must be the same.
 */
-func Provider(ctx *cli.Context, flagDelim string, ko *koanf.Koanf, koDelim string) *Cli {
+func Provider(ctx *cli.Context, flagDelim string, ko *koanf.Koanf) *Cli {
 	return &Cli{
-		delim:   flagDelim,
-		ko:      ko,
-		koDelim: koDelim,
-		ctx:     ctx,
+		delim: flagDelim,
+		ko:    ko,
+		ctx:   ctx,
 	}
 }
 
@@ -48,7 +45,7 @@ func (p *Cli) Read() (map[string]interface{}, error) {
 		// it should not override the value in the conf map (if it exists in the first place).
 		if !p.ctx.IsSet(flagName) {
 			if p.ko != nil {
-				newFlag := strings.ReplaceAll(flagName, p.delim, p.koDelim)
+				newFlag := strings.ReplaceAll(flagName, p.delim, p.ko.Delim())
 				if p.ko.Exists(newFlag) {
 					continue
 				}

--- a/repository/github/labels.go
+++ b/repository/github/labels.go
@@ -1,0 +1,101 @@
+package github
+
+import (
+	"github.com/ccremer/greposync/cfg"
+	"github.com/google/go-github/v37/github"
+)
+
+type (
+	LabelConfig struct {
+		Labels []cfg.RepositoryLabel
+	}
+)
+
+func (p *Provider) UpdateLabels(c LabelConfig) error {
+	if len(c.Labels) == 0 {
+		p.log.InfoF("No labels defined in config, nothing to do.")
+		return nil
+	}
+	nextPage := 1
+	lastPage := 1
+	var allLabels []*github.Label
+	for repeat := true; repeat; repeat = nextPage < lastPage {
+		labels, resp, err := p.client.Issues.ListLabels(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, &github.ListOptions{
+			Page:    1,
+			PerPage: 100,
+		})
+		if err != nil {
+			return err
+		}
+		p.setRemainingApiCalls(resp)
+		allLabels = append(allLabels, labels...)
+		lastPage = resp.LastPage
+		nextPage = resp.NextPage
+	}
+
+	for _, label := range c.Labels {
+		ghLabel := p.findGhLabel(allLabels, label)
+		err := p.upsertLabel(ghLabel, label)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *Provider) upsertLabel(ghLabel *github.Label, label cfg.RepositoryLabel) error {
+	var resp *github.Response
+	var err error
+	if ghLabel != nil && p.hasLabelChanged(ghLabel, label) {
+		_, resp, err = p.client.Issues.EditLabel(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, label.Name, ghLabel)
+		p.setRemainingApiCalls(resp)
+		if err != nil {
+			return err
+		}
+		p.log.InfoF("Label '%s' updated", label.Name)
+	} else if ghLabel == nil {
+		_, resp, err = p.client.Issues.CreateLabel(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, &github.Label{
+			Name:        &label.Name,
+			Color:       &label.Color,
+			Description: &label.Description,
+		})
+		p.setRemainingApiCalls(resp)
+		if err != nil {
+			return err
+		}
+		p.log.InfoF("Label '%s' created", label.Name)
+	} else if label.Delete {
+		resp, err = p.client.Issues.DeleteLabel(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, label.Name)
+		p.setRemainingApiCalls(resp)
+		if err != nil {
+			return err
+		}
+		p.log.InfoF("Label '%s' deleted", label.Name)
+	} else {
+		p.log.InfoF("Label '%s' unchanged", label.Name)
+	}
+	return nil
+}
+
+func (p *Provider) findGhLabel(ghLabels []*github.Label, toFind cfg.RepositoryLabel) *github.Label {
+	for _, label := range ghLabels {
+		if label.GetName() == toFind.Name {
+			return label
+		}
+	}
+	return nil
+}
+
+func (p *Provider) hasLabelChanged(ghLabel *github.Label, repoLabel cfg.RepositoryLabel) bool {
+	changed := false
+	if ghLabel.GetDescription() != repoLabel.Description {
+		ghLabel.Description = &repoLabel.Description
+		changed = true
+	}
+	if ghLabel.GetColor() != repoLabel.Color {
+		ghLabel.Color = &repoLabel.Color
+		changed = true
+	}
+	return changed
+}

--- a/repository/github/pr.go
+++ b/repository/github/pr.go
@@ -1,67 +1,34 @@
 package github
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/ccremer/greposync/printer"
 	"github.com/google/go-github/v37/github"
-	"golang.org/x/oauth2"
 )
 
 type (
-	// Config configures the GitHub provider with all necessary information.
-	Config struct {
-		Token        string
+	// PrConfig is a config required for managing PRs.
+	PrConfig struct {
 		Subject      string
-		Repo         string
-		RepoOwner    string
 		CommitBranch string
 		TargetBranch string
 		Body         string
 		Labels       []string
 	}
-	// PrProvider contains the methods and data to interact with the GitHub API.
-	PrProvider struct {
-		cfg    *Config
-		client *github.Client
-		ctx    context.Context
-		log    printer.Printer
-	}
 )
-
-func (p *PrProvider) createClient() {
-	p.ctx = context.Background()
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: p.cfg.Token},
-	)
-	tc := oauth2.NewClient(p.ctx, ts)
-
-	p.client = github.NewClient(tc)
-}
-
-// NewProvider returns a new GitHub provider instance.
-func NewProvider(config *Config) *PrProvider {
-	provider := &PrProvider{
-		cfg: config,
-		log: printer.New().SetName(config.Repo).SetLevel(printer.DefaultLevel),
-	}
-	provider.createClient()
-	return provider
-}
 
 // CreateOrUpdatePr creates the PR if it doesn't exist, or updates an existing one if the branch matches.
 // A PR is considered out-of-date if the subject or body don't match with current configuration.
 // Labels are left unmodified.
-func (p *PrProvider) CreateOrUpdatePr() error {
-	if pr, err := p.findExistingPr(); err != nil {
+func (p *Provider) CreateOrUpdatePr(c *PrConfig) error {
+	if pr, err := p.findExistingPr(c); err != nil {
 		return err
 	} else if pr == nil {
-		return p.createPR()
+		return p.createPR(c)
 	} else {
-		if *pr.Body != p.cfg.Body || *pr.Title != p.cfg.Subject {
+		if *pr.Body != c.Body || *pr.Title != c.Subject {
 			p.log.InfoF("Updating PR#%d", *pr.Number)
-			return p.updatePr(pr)
+			return p.updatePr(c, pr)
 		} else {
 			p.log.InfoF("PR#%d is up-to-date.", *pr.Number)
 			return nil
@@ -69,14 +36,15 @@ func (p *PrProvider) CreateOrUpdatePr() error {
 	}
 }
 
-func (p *PrProvider) findExistingPr() (*github.PullRequest, error) {
-	p.log.DebugF("Searching existing PRs with same branch %s...", p.cfg.CommitBranch)
-	list, _, err := p.client.PullRequests.List(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, &github.PullRequestListOptions{
-		Head: fmt.Sprintf("%s:%s", p.cfg.RepoOwner, p.cfg.CommitBranch),
+func (p *Provider) findExistingPr(c *PrConfig) (*github.PullRequest, error) {
+	p.log.DebugF("Searching existing PRs with same branch %s...", c.CommitBranch)
+	list, resp, err := p.client.PullRequests.List(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, &github.PullRequestListOptions{
+		Head: fmt.Sprintf("%s:%s", p.cfg.RepoOwner, c.CommitBranch),
 	})
 	if err != nil {
 		return nil, err
 	}
+	p.setRemainingApiCalls(resp)
 	if len(list) > 0 {
 		return list[0], nil
 	}
@@ -84,39 +52,42 @@ func (p *PrProvider) findExistingPr() (*github.PullRequest, error) {
 }
 
 // createPR creates a pull request. Based on: https://godoc.org/github.com/google/go-github/github#example-PullRequestsService-Create
-func (p *PrProvider) createPR() (err error) {
+func (p *Provider) createPR(c *PrConfig) (err error) {
 	p.log.DebugF("Creating new PR")
 	newPR := &github.NewPullRequest{
-		Title:               &p.cfg.Subject,
-		Head:                &p.cfg.CommitBranch,
-		Base:                &p.cfg.TargetBranch,
-		Body:                &p.cfg.Body,
+		Title:               &c.Subject,
+		Head:                &c.CommitBranch,
+		Base:                &c.TargetBranch,
+		Body:                &c.Body,
 		MaintainerCanModify: github.Bool(true),
 	}
 
-	pr, _, err := p.client.PullRequests.Create(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, newPR)
+	pr, resp, err := p.client.PullRequests.Create(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, newPR)
 	if err != nil {
 		return err
 	}
+	p.setRemainingApiCalls(resp)
 
-	if len(p.cfg.Labels) > 0 {
-		p.addLabels(*pr.Number)
+	if len(c.Labels) > 0 {
+		p.addLabels(c, *pr.Number)
 	}
 
 	p.log.InfoF("PR created: %s", pr.GetHTMLURL())
 	return nil
 }
 
-func (p *PrProvider) addLabels(issueNumber int) {
-	_, _, err := p.client.Issues.AddLabelsToIssue(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, issueNumber, p.cfg.Labels)
+func (p *Provider) addLabels(c *PrConfig, issueNumber int) {
+	_, resp, err := p.client.Issues.AddLabelsToIssue(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, issueNumber, c.Labels)
 	if err != nil {
 		p.log.WarnF("could not add label, ignoring error: " + err.Error())
 	}
+	p.setRemainingApiCalls(resp)
 }
 
-func (p *PrProvider) updatePr(pr *github.PullRequest) error {
-	pr.Body = &p.cfg.Body
-	pr.Title = &p.cfg.Subject
-	_, _, err := p.client.PullRequests.Edit(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, *pr.Number, pr)
+func (p *Provider) updatePr(c *PrConfig, pr *github.PullRequest) error {
+	pr.Body = &c.Body
+	pr.Title = &c.Subject
+	_, resp, err := p.client.PullRequests.Edit(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, *pr.Number, pr)
+	p.setRemainingApiCalls(resp)
 	return err
 }

--- a/repository/github/provider.go
+++ b/repository/github/provider.go
@@ -1,0 +1,74 @@
+package github
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/ccremer/greposync/cfg"
+	"github.com/ccremer/greposync/printer"
+	"github.com/google/go-github/v37/github"
+	"golang.org/x/oauth2"
+)
+
+type (
+	// Config configures the GitHub provider with all necessary information.
+	Config struct {
+		Token     string
+		Repo      string
+		RepoOwner string
+	}
+	// Provider contains the methods and data to interact with the GitHub API.
+	Provider struct {
+		cfg               *Config
+		client            *github.Client
+		ctx               context.Context
+		log               printer.Printer
+		remainingApiCalls int64
+	}
+)
+
+func (p *Provider) convertLabelsToRepoLabels(labels []*github.Label) []cfg.RepositoryLabel {
+	var list []cfg.RepositoryLabel
+	for _, label := range labels {
+		list = append(list, cfg.RepositoryLabel{
+			Name:        label.GetName(),
+			Color:       label.GetColor(),
+			Description: label.GetDescription(),
+		})
+	}
+	return list
+}
+
+// NewProvider returns a new GitHub provider instance.
+func NewProvider(config *Config) *Provider {
+	ctx, client := createClient(config.Token)
+	provider := &Provider{
+		cfg:    config,
+		client: client,
+		ctx:    ctx,
+		log:    printer.New().SetName(config.Repo).SetLevel(printer.DefaultLevel),
+	}
+	return provider
+}
+
+func createClient(token string) (context.Context, *github.Client) {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := github.NewClient(tc)
+	return ctx, client
+}
+
+func (p *Provider) setRemainingApiCalls(resp *github.Response) {
+	if resp != nil {
+		atomic.StoreInt64(&p.remainingApiCalls, int64(resp.Rate.Remaining))
+	}
+}
+
+// GetRemainingApiCalls returns the amount of remaining rate-limited API request based on the last API request made.
+func (p *Provider) GetRemainingApiCalls() int {
+	return int(atomic.LoadInt64(&p.remainingApiCalls))
+}

--- a/repository/labels.go
+++ b/repository/labels.go
@@ -1,0 +1,23 @@
+package repository
+
+import (
+	pipeline "github.com/ccremer/go-command-pipeline"
+	"github.com/ccremer/greposync/cfg"
+	"github.com/ccremer/greposync/repository/github"
+)
+
+// CreateOrUpdateLabels creates or updates the labels configured.
+func (s *Service) CreateOrUpdateLabels(config map[string]cfg.RepositoryLabel) pipeline.ActionFunc {
+	return func() pipeline.Result {
+		lc := github.LabelConfig{Labels: toArray(config)}
+		return pipeline.Result{Err: s.provider.UpdateLabels(lc)}
+	}
+}
+
+func toArray(labels map[string]cfg.RepositoryLabel) []cfg.RepositoryLabel {
+	var list []cfg.RepositoryLabel
+	for _, v := range labels {
+		list = append(list, v)
+	}
+	return list
+}

--- a/repository/pr.go
+++ b/repository/pr.go
@@ -8,23 +8,32 @@ import (
 	"github.com/ccremer/greposync/repository/github"
 )
 
-// CreateOrUpdatePr creates a PR if it doesn't exist or updates if the remote branch exists already.
-func (s *Service) CreateOrUpdatePr(config *cfg.PullRequestConfig) pipeline.ActionFunc {
+// InitializeGitHubProvider prepares a new GitHub provider instance for later use.
+func (s *Service) InitializeGitHubProvider(config *cfg.PullRequestConfig) pipeline.ActionFunc {
 	return func() pipeline.Result {
 		if config.TargetBranch == "" {
 			config.TargetBranch = s.Config.DefaultBranch
 		}
 		c := &github.Config{
-			Token:        os.Getenv("GITHUB_TOKEN"),
+			Token:     os.Getenv("GITHUB_TOKEN"),
+			Repo:      s.Config.Name,
+			RepoOwner: s.Config.Namespace,
+		}
+		s.provider = github.NewProvider(c)
+		return pipeline.Result{}
+	}
+}
+
+// CreateOrUpdatePr creates a PR if it doesn't exist or updates if the remote branch exists already.
+func (s *Service) CreateOrUpdatePr(config *cfg.PullRequestConfig) pipeline.ActionFunc {
+	return func() pipeline.Result {
+		prc := &github.PrConfig{
 			Subject:      config.Subject,
-			Repo:         s.Config.Name,
-			RepoOwner:    s.Config.Namespace,
 			CommitBranch: s.Config.CommitBranch,
 			TargetBranch: config.TargetBranch,
 			Body:         config.BodyTemplate,
 			Labels:       config.Labels,
 		}
-		gh := github.NewProvider(c)
-		return pipeline.Result{Err: gh.CreateOrUpdatePr()}
+		return pipeline.Result{Err: s.provider.CreateOrUpdatePr(prc)}
 	}
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ccremer/greposync/cfg"
 	"github.com/ccremer/greposync/printer"
+	"github.com/ccremer/greposync/repository/github"
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/file"
@@ -19,8 +20,9 @@ import (
 type (
 	// Service represents a git repository that comes with utility methods
 	Service struct {
-		p      printer.Printer
-		Config *cfg.GitConfig
+		p        printer.Printer
+		Config   *cfg.GitConfig
+		provider *github.Provider
 	}
 	// ManagedGitRepo is the representation of the managed git repos in the config file.
 	ManagedGitRepo struct {


### PR DESCRIPTION
## Summary

* Adds `gsync labels` subcommand to synchronize issue labels across all repositories

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
