### PR TITLE
Skip PR creation on empty changes

### DIFF
--- a/repository/github/pr.go
+++ b/repository/github/pr.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-github/v37/github"
 )
@@ -64,6 +65,10 @@ func (p *Provider) createPR(c *PrConfig) (err error) {
 
 	pr, resp, err := p.client.PullRequests.Create(p.ctx, p.cfg.RepoOwner, p.cfg.Repo, newPR)
 	if err != nil {
+		if strings.Contains(err.Error(), "No commits between") {
+			p.log.InfoF("No pull request created as there are no commits between '%s' and '%s'", c.TargetBranch, c.CommitBranch)
+			return nil
+		}
 		return err
 	}
 	p.setRemainingApiCalls(resp)

--- a/repository/push.go
+++ b/repository/push.go
@@ -27,3 +27,10 @@ func (s *Service) EnabledPush() predicate.Predicate {
 		return !s.Config.SkipPush
 	}
 }
+
+// IfBranchHasCommits returns true if the local commit branch has at least 1 commit.
+func (s *Service) IfBranchHasCommits() predicate.Predicate {
+	return func(step pipeline.Step) bool {
+		return s.branchHasCommits()
+	}
+}


### PR DESCRIPTION
## Summary

* Only pushes changes if there's at least 1 commit
* Ignores an error from GitHub if there's no change

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Update documentation.
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
