### PR TITLE
Fix file permissions not being updated

### DIFF
--- a/pkg/rendering/template.go
+++ b/pkg/rendering/template.go
@@ -123,6 +123,11 @@ func (s *GoTemplateService) writeTemplate(output core.Output, t *template.Templa
 	defer unix.Umask(originalUmask)
 
 	fileName := path.Join(output.Git.RootDir, output.TargetPath)
+	if fileExists(fileName) {
+		if err := os.Remove(fileName); err != nil {
+			return err
+		}
+	}
 	f, err := os.OpenFile(fileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, output.Template.FileMode)
 	if err != nil {
 		return err


### PR DESCRIPTION

## Summary
If the file is existing with different perm than the template, the permissions are left untouched.
This commit fixes this by removing the file first.



## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
