### PR TITLE
Setup automatic versioning for Antora documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - doc-gen
     tags:
       - "*"
 
@@ -16,41 +15,53 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+    - name: Configure Git
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+
     - name: Parse semver string
       id: semver
       uses: booxmedialtd/ws-action-parse-semver@v1
       with:
         input_string: ${{ github.ref }}
         version_extractor_regex: '\/v(.*)$'
-    - name: Configure Git
+    - name: Set variables
       run: |
-        git config user.name "GitHub Actions"
-        git config user.email "actions@github.com"
-    - name: Set branch name
-      run: echo MINOR_VERSION=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }} >> $GITHUB_ENV
+        echo "MINOR_VERSION=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
+        echo "BRANCH_NAME=docs/v${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
+    - name: Set branch name for Prerelease
+      if: ${{ steps.semver.outputs.prerelease != '' }}
+      # Cover all prereleases in one single rc branch. Administrator should manually delete the docs/vX.Y-rc branches from time to time for cleanup
+      run: echo "BRANCH_NAME=docs/v${{ env.MINOR_VERSION}}-rc" >> $GITHUB_ENV
+
     - name: Checkout remote branch if exists
-      run: git checkout docs/v${{ env.MINOR_VERSION }}
+      run: git checkout ${{ env.BRANCH_NAME }}
       continue-on-error: true
     - name: Rebase if possible
-      run: git rebase ${GITHUB_REF##*/} docs/v${{ env.MINOR_VERSION }}
+      run: git rebase ${GITHUB_REF##*/} ${{ env.BRANCH_NAME }}
       continue-on-error: true
-      # Don't rebase on prereleases. Users that want to view prereleases are encouraged to run a local preview.
-      if: ${{ steps.semver.outputs.prerelease == '' }}
     - name: Create new branch if not existing
-      run: git switch --create docs/v${{ env.MINOR_VERSION }}
+      run: git switch --create ${{ env.BRANCH_NAME }}
       continue-on-error: true
-    - name: Patch Antora file
+
+    - name: Patch Antora file for Release
       run: yq eval 'del(.prerelease) | del (.display_version) | .version = "${{ env.MINOR_VERSION }}"' -i docs/antora.yml
+      if: ${{ steps.semver.outputs.prerelease == '' }}
+    - name: Patch Antora file for Prerelease
+      run: yq eval 'del (.display_version) | .version = "${{ env.MINOR_VERSION }}", .prerelease = "-${{ steps.semver.outputs.prerelease }}"' -i docs/antora.yml
+      if: ${{ steps.semver.outputs.prerelease != '' }}
+
     - name: Commit
       run: git commit -am "Update version for Antora" --author "GitHub Actions <actions@github.com>"
       continue-on-error: true
     - name: Push
-      run: git push --atomic --force --set-upstream origin docs/v${{ env.MINOR_VERSION }}
+      run: git push --atomic --force --set-upstream origin ${{ env.BRANCH_NAME }}
 
   gh-pages:
     runs-on: ubuntu-latest
+    # These will cause this job to wait until Antora versioning is done for tags, but still run on master branch
     needs: antora
-    # This ensure that we still run on master branches
     if: always()
     steps:
     - uses: actions/checkout@v2
@@ -59,7 +70,7 @@ jobs:
     - name: Configure Git
       run: |
         git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-        git config user.name "${{ github.actor }}"
-        git config user.email "${{ github.actor }}@users.noreply.github.com"
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
     - name: Publish documentation
       run: make docs:publish

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,12 +4,58 @@ on:
   push:
     branches:
       - master
+      - doc-gen
+    tags:
+      - "*"
 
 jobs:
-  gh-pages:
+  antora:
     runs-on: ubuntu-latest
+    if: ${{ contains(github.ref, 'tags') }}
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Parse semver string
+      id: semver
+      uses: booxmedialtd/ws-action-parse-semver@v1
+      with:
+        input_string: ${{ github.ref }}
+        version_extractor_regex: '\/v(.*)$'
+    - name: Configure Git
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+    - name: Set branch name
+      run: echo MINOR_VERSION=${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }} >> $GITHUB_ENV
+    - name: Checkout remote branch if exists
+      run: git checkout docs/v${{ env.MINOR_VERSION }}
+      continue-on-error: true
+    - name: Rebase if possible
+      run: git rebase ${GITHUB_REF##*/} docs/v${{ env.MINOR_VERSION }}
+      continue-on-error: true
+      # Don't rebase on prereleases. Users that want to view prereleases are encouraged to run a local preview.
+      if: ${{ steps.semver.outputs.prerelease == '' }}
+    - name: Create new branch if not existing
+      run: git switch --create docs/v${{ env.MINOR_VERSION }}
+      continue-on-error: true
+    - name: Patch Antora file
+      run: yq eval 'del(.prerelease) | del (.display_version) | .version = "${{ env.MINOR_VERSION }}"' -i docs/antora.yml
+    - name: Commit
+      run: git commit -am "Update version for Antora" --author "GitHub Actions <actions@github.com>"
+      continue-on-error: true
+    - name: Push
+      run: git push --atomic --force --set-upstream origin docs/v${{ env.MINOR_VERSION }}
+
+  gh-pages:
+    runs-on: ubuntu-latest
+    needs: antora
+    # This ensure that we still run on master branches
+    if: always()
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Configure Git
       run: |
         git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,7 +7,7 @@ MAKEFLAGS += --no-builtin-variables
 .SUFFIXES:
 .SECONDARY:
 
-ANTORA_PLAYBOOK_PATH ?= local-antora-playbook.yml
+ANTORA_PLAYBOOK_PATH ?= antora-playbook.yml
 ANTORA_OUTPUT_DIR ?= $(shell grep "dir" $(ANTORA_PLAYBOOK_PATH) | cut -d " " -f 4)
 
 .PHONY: build

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -5,7 +5,9 @@ site:
 content:
   sources:
     - url: ../
-      branches: [HEAD]
+      branches:
+        - HEAD
+        - docs/v*
       start_path: docs
 ui:
   bundle:

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -3,7 +3,6 @@ title: greposync
 nav:
 - modules/ROOT/nav.adoc
 
-# This will be overridden from the playbook, only relevant for local preview now
-version: latest
-# This is a custom property using an Antora hack:
-use_ref: true
+version: master
+prerelease: true
+display_version: master

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,7 +1,7 @@
 name: greposync
 title: greposync
 nav:
-- modules/ROOT/nav.adoc
+  - modules/ROOT/nav.adoc
 
 version: master
 prerelease: true

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "watch": "1.0.2"
   },
   "scripts": {
-    "build": "antora ${ANTORA_PLAYBOOK_PATH:-local-antora-playbook.yml} ${ANTORA_ARGS}",
+    "build": "antora ${ANTORA_PLAYBOOK_PATH:-antora-playbook.yml} ${ANTORA_ARGS}",
     "watch": "watch 'npm run build' modules",
     "serve": "reload -d public -b",
     "preview": "run-p watch serve",


### PR DESCRIPTION

## Summary

This should now build documentation for tags using a "release" branch just for Antora

* Builds documentation with pushes to `master`. Master branch is considered Antora "prerelease"
  * Includes any branches matching "docs/v*" as releases.
  * Includes branches matching "docs/v*-rc* as prereleases.

* Builds documentation with `tag` pushes.
  * Creates a new branch with Major and Minor pattern, e.g. `v1.2.3` will create branch `docs/v1.2`
  * Patch versions will cause the branch to be rebased onto the tag
  * Prereleases will get their own branch per minor version, e.g. `v1.2.3-rc1` will create branch `docs/v1.2-rc`
  * All Prereleases belonging to the same minor version will cause the branch to be rebased onto latest matching rc tag.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
