### PR TITLE
Automatically cleanup prerelease branch on full releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,8 +32,7 @@ jobs:
         echo "BRANCH_NAME=docs/v${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}" >> $GITHUB_ENV
     - name: Set branch name for Prerelease
       if: ${{ steps.semver.outputs.prerelease != '' }}
-      # Cover all prereleases in one single rc branch. Administrator should manually delete the docs/vX.Y-rc branches from time to time for cleanup
-      run: echo "BRANCH_NAME=docs/v${{ env.MINOR_VERSION}}-rc" >> $GITHUB_ENV
+      run: echo "BRANCH_NAME=${{ env.BRANCH_NAME }}-rc" >> $GITHUB_ENV
 
     - name: Checkout remote branch if exists
       run: git checkout ${{ env.BRANCH_NAME }}
@@ -57,6 +56,11 @@ jobs:
       continue-on-error: true
     - name: Push
       run: git push --atomic --force --set-upstream origin ${{ env.BRANCH_NAME }}
+
+    - name: Cleanup prerelease branch if existing
+      if: ${{ steps.semver.outputs.prerelease == '' }}
+      run: git push origin --delete ${{ env.BRANCH_NAME }}-rc
+      continue-on-error: true
 
   gh-pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
     - name: Configure Git
       run: |
-        git config user.name "GitHub Actions"
+        git config user.name "Antora via GitHub Actions"
         git config user.email "actions@github.com"
 
     - name: Parse semver string
@@ -52,7 +52,7 @@ jobs:
       if: ${{ steps.semver.outputs.prerelease != '' }}
 
     - name: Commit
-      run: git commit -am "Update version for Antora" --author "GitHub Actions <actions@github.com>"
+      run: git commit --all --message "Update version for Antora"
       continue-on-error: true
     - name: Push
       run: git push --atomic --force --set-upstream origin ${{ env.BRANCH_NAME }}
@@ -74,7 +74,7 @@ jobs:
     - name: Configure Git
       run: |
         git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-        git config user.name "GitHub Actions"
+        git config user.name "Antora via GitHub Actions"
         git config user.email "actions@github.com"
     - name: Publish documentation
       run: make docs:publish


### PR DESCRIPTION
## Summary

Follow-up of #86 
* This will automatically delete the corresponding `-rc` branch if the full release is pending.
* This workflow effectively enables: View documentation for prereleases, but cleanup the release from Antora after full release.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
