### PR TITLE
Switch container registry to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,20 +27,20 @@ jobs:
     #   uses: crazy-max/ghaction-import-gpg@v3
     #   with:
     #     gpg-private-key: ${{ secrets.SIGNING_KEY }}
-    - name: Login to quay.io
+    - name: Login to ghcr.io
       uses: docker/login-action@v1
       with:
-        registry: quay.io
-        username: ${{ secrets.QUAY_IO_USER }}
-        password: ${{ secrets.QUAY_IO_PASSWORD }}
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build changelog from PRs with labels
       id: build_changelog
       uses: mikepenz/release-changelog-builder-action@v2
       with:
         configuration: ".github/changelog-configuration.json"
         # PreReleases still get a changelog, but the next full release gets a diff since the last full release,
-        # combining possible changelogs of all previous PreReleases in between. PreReleases show a partial changelog
-        # since last PreRelease.
+        # combining possible changelogs of all previous PreReleases in between.
+        # PreReleases show a partial changelog since last PreRelease.
         ignorePreReleases: "${{ !contains(github.ref, '-rc') }}"
         outputFile: .github/release-notes.md
       env:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,12 +34,12 @@ snapshot:
 
 dockers:
 - image_templates:
-  - "quay.io/ccremer/greposync:v{{ .Version }}"
+  - "ghcr.io/ccremer/greposync:v{{ .Version }}"
 
     # For prereleases, updating `latest` and the floating tags of the major version does not make sense.
     # Only the image for the exact version should be pushed.
-  - "{{ if not .Prerelease }}quay.io/ccremer/greposync:v{{ .Major }}{{ end }}"
-  - "{{ if not .Prerelease }}quay.io/ccremer/greposync:latest{{ end }}"
+  - "{{ if not .Prerelease }}ghcr.io/ccremer/greposync:v{{ .Major }}{{ end }}"
+  - "{{ if not .Prerelease }}ghcr.io/ccremer/greposync:latest{{ end }}"
 
 nfpms:
 - vendor: ccremer

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ lint: generate fmt vet ## Invokes the fmt and vet targets
 build\:docker: export CGO_ENABLED = 0
 build\:docker:
 build\:docker: build ## Build the docker image
-	docker build . -t $(QUAY_IMG)
+	docker build . -t $(CONTAINER_IMG)
 
 .PHONY: clean
 clean: ## Clean the project

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -3,7 +3,7 @@
 IMG_TAG ?= latest
 
 # Image URL to use all building/pushing image targets
-QUAY_IMG ?= quay.io/ccremer/greposync:$(IMG_TAG)
+CONTAINER_IMG ?= ghcr.io/ccremer/greposync:$(IMG_TAG)
 
 GOASCIIDOC_OUT_ROOT ?= docs/modules/ROOT
 GOASCIIDOC_OUT_GODOC_PATH ?= $(GOASCIIDOC_OUT_ROOT)/pages/references/godoc.adoc


### PR DESCRIPTION

## Summary

* Switches container registry to `ghcr.io/ccremer/greposync` going forward.
* Previous tags from `quay.io/ccremer/greposync` will NOT be migrated.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
