### PR TITLE
Workaround 'go mod tidy' for Renovate PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,10 @@ build: export GOOS = linux
 build: generate fmt vet ## Build the Go binary
 	@go build -o gsync .
 
-.PHONY: gomodtidy
-gomodtidy:
-	go mod tidy
-	# Hack to get the missing go.sum entry...
-	go get github.com/google/wire/cmd/wire@v0.5.0
-
+# Using GOFLAGS here to workaround a broken import (https://github.com/google/wire/issues/299)
 .PHONY: generate
-generate: gomodtidy
-	go generate -tags=generate generate.go
+generate:
+	GOFLAGS=-mod=mod go generate -tags=generate generate.go
 	$(GOASCIIDOC_CMD) domain
 	cp application/initialize/_helpers.tpl docs/modules/ROOT/examples/comment/helpers.tpl
 

--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,5 @@
   ],
   "labels": [
     "dependency"
-  ],
-  "postUpdateOptions": [
-    "gomodTidy"
   ]
 }


### PR DESCRIPTION
## Summary

This workaround means that 'go mod tidy' has to be executed manually once in a while.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
