### PR TITLE
Fix wire import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,9 @@ build: export GOOS = linux
 build: generate fmt vet ## Build the Go binary
 	@go build -o gsync .
 
-# Using GOFLAGS here to workaround a broken import (https://github.com/google/wire/issues/299)
 .PHONY: generate
 generate:
-	GOFLAGS=-mod=mod go generate -tags=generate generate.go
+	go generate -tags=generate generate.go
 	$(GOASCIIDOC_CMD) domain
 	cp application/initialize/_helpers.tpl docs/modules/ROOT/examples/comment/helpers.tpl
 

--- a/go.sum
+++ b/go.sum
@@ -374,8 +374,6 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e h1:WUoyKPm6nCo1BnNUvPGnFG3T5DUVem42yDJZZ4CNxMA=
-golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210930141918-969570ce7c6c h1:ayiZ33F3u3LIXB03Y5VKNdaFO79a18Fr+SB30o/KFyw=
 golang.org/x/sys v0.0.0-20210930141918-969570ce7c6c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,8 @@
   ],
   "labels": [
     "dependency"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }

--- a/tools.go
+++ b/tools.go
@@ -5,6 +5,6 @@
 package tools
 
 import (
-	_ "github.com/google/wire"
+	_ "github.com/google/wire/cmd/wire"
 	_ "github.com/mariotoffia/goasciidoc"
 )


### PR DESCRIPTION
## Summary
* Fixes the import path of Google wire, so that future Renovate PRs can be created without them inadvertently deleting lines by `go mod tidy`

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
