### PR TITLE
Fix loading of variables for templates with ".tpl" in the name

### DIFF
--- a/docs/modules/developer-guide/pages/ref-domain.adoc
+++ b/docs/modules/developer-guide/pages/ref-domain.adoc
@@ -735,6 +735,14 @@ func (t *Template) Render(values Values, engine TemplateEngine) (RenderResult, e
 
 Render takes the given Values and returns a RenderResult from the given TemplateEngine.
 
+.CleanPath
+[source, go]
+----
+func (t *Template) CleanPath() Path
+----
+
+CleanPath returns a new Path with the first occurrence of ".tpl" in the base file name removed.
+
 
 '''
 
@@ -1193,6 +1201,7 @@ func NewTemplate(relPath Path, perms Permissions) *Template
 ----
 
 NewTemplate returns a new instance.
+
 
 
 

--- a/domain/render_service.go
+++ b/domain/render_service.go
@@ -91,7 +91,7 @@ func (ctx *RenderContext) renderTemplate(template *Template) error {
 		return err
 	}
 
-	targetPath := template.RelativePath
+	targetPath := template.CleanPath()
 	if alternativePath != "" {
 		targetPath = alternativePath
 	}

--- a/domain/template.go
+++ b/domain/template.go
@@ -2,6 +2,8 @@ package domain
 
 import (
 	"io/fs"
+	"path"
+	"strings"
 )
 
 // Permissions is an alias for file permissions.
@@ -28,6 +30,14 @@ func NewTemplate(relPath Path, perms Permissions) *Template {
 func (t *Template) Render(values Values, engine TemplateEngine) (RenderResult, error) {
 	content, err := engine.Execute(t, values)
 	return content, err
+}
+
+// CleanPath returns a new Path with the first occurrence of ".tpl" in the base file name removed.
+func (t *Template) CleanPath() Path {
+	dirName := path.Dir(t.RelativePath.String())
+	baseName := path.Base(t.RelativePath.String())
+	newName := strings.Replace(baseName, ".tpl", "", 1)
+	return NewPath(dirName, newName)
 }
 
 // FileMode converts Permissions to fs.FileMode.

--- a/domain/template_test.go
+++ b/domain/template_test.go
@@ -1,0 +1,46 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTemplate_CleanPath(t *testing.T) {
+	tests := map[string]struct {
+		givenPath    Path
+		expectedPath Path
+	}{
+		"GivenFile_WhenNoExtension_ThenExpectSame": {
+			givenPath:    NewPath("readme"),
+			expectedPath: NewPath("readme"),
+		},
+		"GivenFile_WhenNoSpecialExtension_ThenExpectSame": {
+			givenPath:    NewPath("readme.md"),
+			expectedPath: NewPath("readme.md"),
+		},
+		"GivenFileInDir_WhenNoExtension_ThenExpectSame": {
+			givenPath:    NewPath("dir", "readme.md"),
+			expectedPath: NewPath("dir", "readme.md"),
+		},
+		"GivenFile_WhenExtension_ThenRemoveIt": {
+			givenPath:    NewPath("readme.md.tpl"),
+			expectedPath: NewPath("readme.md"),
+		},
+		"GivenFile_WhenExtensionTwice_ThenRemoveOne": {
+			givenPath:    NewPath("readme.md.tpl.tpl"),
+			expectedPath: NewPath("readme.md.tpl"),
+		},
+		"GivenFileInDir_WhenExtension_ThenRemoveFromFileName": {
+			givenPath:    NewPath("dir", "readme.tpl.md"),
+			expectedPath: NewPath("dir", "readme.md"),
+		},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			template := NewTemplate(tt.givenPath, Permissions(0))
+			result := template.CleanPath()
+			assert.Equal(t, tt.expectedPath, result)
+		})
+	}
+}

--- a/infrastructure/valuestore/koanfstore.go
+++ b/infrastructure/valuestore/koanfstore.go
@@ -41,7 +41,7 @@ func (k *KoanfValueStore) FetchValuesForTemplate(template *domain.Template, conf
 	if err != nil {
 		return domain.Values{}, err
 	}
-	return k.loadDataForTemplate(repoKoanf, template.RelativePath.String())
+	return k.loadValuesForTemplate(repoKoanf, template.CleanPath().String())
 }
 
 // FetchUnmanagedFlag implements domain.ValueStore.
@@ -51,7 +51,7 @@ func (k *KoanfValueStore) FetchUnmanagedFlag(template *domain.Template, config *
 	if err != nil {
 		return false, err
 	}
-	return k.loadBooleanFlag(repoKoanf, template.RelativePath.String(), "unmanaged")
+	return k.loadBooleanFlag(repoKoanf, template.CleanPath().String(), "unmanaged")
 }
 
 // FetchTargetPath implements domain.ValueStore.
@@ -61,7 +61,7 @@ func (k *KoanfValueStore) FetchTargetPath(template *domain.Template, config *dom
 	if err != nil {
 		return "", err
 	}
-	return k.loadTargetPath(repoKoanf, template.RelativePath.String())
+	return k.loadTargetPath(repoKoanf, template.CleanPath().String())
 }
 
 // FetchFilesToDelete implements domain.ValueStore.
@@ -100,7 +100,7 @@ func (k *KoanfValueStore) loadAndMergeConfig(repository *domain.GitRepository) (
 	return repoKoanf, k.instrumentation.loadedConfigIfNil(repository.URL.GetFullName(), err)
 }
 
-func (k *KoanfValueStore) loadDataForTemplate(repoKoanf *koanf.Koanf, templateFileName string) (domain.Values, error) {
+func (k *KoanfValueStore) loadValuesForTemplate(repoKoanf *koanf.Koanf, templateFileName string) (domain.Values, error) {
 	// Load the global variables into exposed values
 	data := make(domain.Values)
 	err := repoKoanf.Unmarshal(":globals", &data)

--- a/infrastructure/valuestore/koanfstore_test.go
+++ b/infrastructure/valuestore/koanfstore_test.go
@@ -82,7 +82,7 @@ func TestKoanfValueStore_loadDataForTemplate(t *testing.T) {
 			s := NewValueStore(nil)
 			k := koanf.New(".")
 			require.NoError(t, k.Load(file.Provider(filepath.Join("testdata", tt.givenSyncFile)), yaml.Parser()))
-			result, err := s.loadDataForTemplate(k, tt.givenTemplateFileName)
+			result, err := s.loadValuesForTemplate(k, tt.givenTemplateFileName)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expectedConf, result)
 		})

--- a/infrastructure/valuestore/specialflags.go
+++ b/infrastructure/valuestore/specialflags.go
@@ -39,7 +39,7 @@ func pathIsFile(filePath string) bool {
 }
 
 func (k *KoanfValueStore) loadBooleanFlag(repoKoanf *koanf.Koanf, relativePath, flagName string) (bool, error) {
-	values, err := k.loadDataForTemplate(repoKoanf, relativePath)
+	values, err := k.loadValuesForTemplate(repoKoanf, relativePath)
 	if err != nil {
 		return false, err
 	}
@@ -51,7 +51,7 @@ func (k *KoanfValueStore) loadBooleanFlag(repoKoanf *koanf.Koanf, relativePath, 
 }
 
 func (k *KoanfValueStore) loadTargetPath(repoKoanf *koanf.Koanf, relativePath string) (domain.Path, error) {
-	values, err := k.loadDataForTemplate(repoKoanf, relativePath)
+	values, err := k.loadValuesForTemplate(repoKoanf, relativePath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary

* Fixes a regression that when template file like `.gitignore.tpl` would not load the variables in .sync.yml for `.gitignore`.

During DDD refactoring this behavior got forgotten.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [ ] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
