### PR TITLE
Document available metadata fields in template variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ generate:
 	go generate -tags=generate generate.go
 	$(GOASCIIDOC_CMD) domain
 	cp application/initialize/_helpers.tpl docs/modules/ROOT/examples/comment/helpers.tpl
+	cp domain/testdata/golden/metadata.txt docs/modules/ROOT/examples/code/metadata.tpl
 
 .PHONY: fmt
 fmt: ## Run 'go fmt' against code

--- a/docs/antora-playbook.yml
+++ b/docs/antora-playbook.yml
@@ -21,3 +21,5 @@ asciidoc:
   attributes:
     gh-owner: ccremer
     gh-repo: greposync
+    defaults-file: config_defaults.yml
+    sync-file: .sync.yml

--- a/docs/modules/ROOT/examples/code/metadata.tpl
+++ b/docs/modules/ROOT/examples/code/metadata.tpl
@@ -1,0 +1,8 @@
+{{ .Metadata.Repository.RootDir }} = repos/github.com/ccremer/greposync
+{{ .Metadata.Repository.FullName }} = github.com/ccremer/greposync
+{{ .Metadata.Repository.Name }} = greposync
+{{ .Metadata.Repository.Namespace }} = ccremer
+{{ .Metadata.Repository.CommitBranch }} = greposync-update
+{{ .Metadata.Repository.DefaultBranch }} = master
+{{ .Metadata.Template.Permissions }} = 0644
+{{ .Metadata.Template.RelativePath }} = testdata/golden/metadata.tpl

--- a/docs/modules/ROOT/pages/references/template.adoc
+++ b/docs/modules/ROOT/pages/references/template.adoc
@@ -25,3 +25,41 @@ This rule exists since some IDEs provide syntax highlighting for Go template and
 A file named `README.tpl.md` will become `README.md` in the target repository.
 If you actually need a file called `README.tpl.md`, you need to name it `README.tpl.tpl.md`.
 ====
+
+== Values
+
+Any value defined in `{defaults-file}` and `{sync-file}` are merged and accessible as variable in `.Values`.
+
+.Accessing variables in templates
+[example]
+====
+.{sync-file}
+[source,yaml]
+----
+README.md:
+  sections:
+    - section 1
+----
+
+.README.md.tpl
+[source,go]
+----
+# {{ .Values.sections[0] }}
+----
+====
+
+NOTE: Inexisting keys will cause an abort for the repository update.
+
+=== Metadata
+
+Each template can use additional metadata fields.
+They are exposed in the `.Metadata` field.
+
+.Supported metadata variables
+[example]
+====
+[source]
+----
+include::example$code/metadata.tpl[]
+----
+====

--- a/docs/modules/developer-guide/pages/ref-domain.adoc
+++ b/docs/modules/developer-guide/pages/ref-domain.adoc
@@ -968,6 +968,14 @@ func (r RenderResult) WriteToFile(path Path, permissions Permissions) error
 WriteToFile writes the content to the given Path with given Permissions.
 Otherwise, an error is returned.
 
+.String
+[source, go]
+----
+func (r RenderResult) String() string
+----
+
+String implements fmt.Stringer.
+
 
 '''
 
@@ -1207,6 +1215,8 @@ If nr is nil, then nil is returned.
 ----
 func NewRenderService(instrumentation RenderServiceInstrumentation) *RenderService
 ----
+
+
 
 
 

--- a/domain/render_service.go
+++ b/domain/render_service.go
@@ -108,12 +108,16 @@ func (ctx *RenderContext) loadTemplates() error {
 
 func (ctx *RenderContext) loadValues(template *Template) error {
 	values, err := ctx.ValueStore.FetchValuesForTemplate(template, ctx.Repository)
-	ctx.values = Values{
+	ctx.values = ctx.enrichWithMetadata(values, template)
+	return ctx.instrumentation.FetchedValuesForTemplate(err, template)
+}
+
+func (ctx *RenderContext) enrichWithMetadata(values Values, template *Template) Values {
+	return Values{
 		"Values": values,
 		"Metadata": Values{
 			"Repository": ctx.Repository.AsValues(),
 			"Template":   template.AsValues(),
 		},
 	}
-	return ctx.instrumentation.FetchedValuesForTemplate(err, template)
 }

--- a/domain/render_service_test.go
+++ b/domain/render_service_test.go
@@ -1,0 +1,45 @@
+package domain
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGolden_MetadataValues(t *testing.T) {
+	u, err := url.Parse("https://github.com/ccremer/greposync")
+	require.NoError(t, err)
+	gitUrl := FromURL(u)
+
+	fileName := "testdata/golden/metadata.tpl"
+
+	repository := NewGitRepository(gitUrl, NewPath("repos", gitUrl.GetFullName()))
+	repository.CommitBranch = "greposync-update"
+	repository.DefaultBranch = "master"
+	ctx := RenderContext{
+		Repository: repository,
+	}
+	template := NewTemplate(NewPath(fileName), Permissions(0644))
+
+	file, err := os.Create(fileName)
+	require.NoError(t, err)
+	defer file.Close()
+	for k, _ := range ctx.Repository.AsValues() {
+		placeholder := fmt.Sprintf("{{ .Metadata.Repository.%s }}", k)
+		_, _ = fmt.Fprintf(file, "{{`%s`}} = %s\n", placeholder, placeholder)
+	}
+	for k, _ := range template.AsValues() {
+		placeholder := fmt.Sprintf("{{ .Metadata.Template.%s }}", k)
+		_, _ = fmt.Fprintf(file, "{{`%s`}} = %s\n", placeholder, placeholder)
+	}
+
+	values := ctx.enrichWithMetadata(Values{}, template)
+	engine := DummyEngine{templatePath: fileName}
+	result, err := engine.Execute(template, values)
+	require.NoError(t, err)
+	err = result.WriteToFile(NewPath("testdata", "golden", "metadata.txt"), template.FilePermissions)
+	require.NoError(t, err)
+}

--- a/domain/renderresult.go
+++ b/domain/renderresult.go
@@ -10,3 +10,8 @@ type RenderResult string
 func (r RenderResult) WriteToFile(path Path, permissions Permissions) error {
 	return os.WriteFile(path.String(), []byte(r), permissions.FileMode())
 }
+
+// String implements fmt.Stringer.
+func (r RenderResult) String() string {
+	return string(r)
+}

--- a/domain/template_engine_test.go
+++ b/domain/template_engine_test.go
@@ -1,0 +1,23 @@
+package domain
+
+import (
+	"bytes"
+	"path"
+	"text/template"
+)
+
+type DummyEngine struct {
+	templatePath string
+}
+
+func (d DummyEngine) Execute(templ *Template, values Values) (RenderResult, error) {
+	tpl, err := template.New(path.Base(templ.RelativePath.String())).ParseFiles(d.templatePath)
+	if err != nil {
+		return "", err
+	}
+
+	buf := &bytes.Buffer{}
+	err = tpl.Execute(buf, values)
+
+	return RenderResult(buf.String()), err
+}

--- a/domain/template_test.go
+++ b/domain/template_test.go
@@ -1,12 +1,9 @@
 package domain
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"path"
 	"testing"
-	"text/template"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,12 +55,8 @@ func TestTemplate_AsValues(t *testing.T) {
 	subject := NewTemplate(NewPath(file), Permissions(info.Mode()))
 	values := subject.AsValues()
 
-	tpl, err := template.New(path.Base(file)).ParseFiles(file)
+	engine := DummyEngine{templatePath: file}
+	result, err := engine.Execute(subject, values)
 	require.NoError(t, err)
-
-	buf := &bytes.Buffer{}
-	err = tpl.Execute(buf, values)
-	require.NoError(t, err)
-
-	assert.Equal(t, fmt.Sprintf("%s\n%s\n", file, "0644"), buf.String())
+	assert.Equal(t, fmt.Sprintf("%s\n%s\n", file, "0644"), result.String())
 }

--- a/domain/testdata/golden/metadata.tpl
+++ b/domain/testdata/golden/metadata.tpl
@@ -1,0 +1,8 @@
+{{`{{ .Metadata.Repository.RootDir }}`}} = {{ .Metadata.Repository.RootDir }}
+{{`{{ .Metadata.Repository.FullName }}`}} = {{ .Metadata.Repository.FullName }}
+{{`{{ .Metadata.Repository.Name }}`}} = {{ .Metadata.Repository.Name }}
+{{`{{ .Metadata.Repository.Namespace }}`}} = {{ .Metadata.Repository.Namespace }}
+{{`{{ .Metadata.Repository.CommitBranch }}`}} = {{ .Metadata.Repository.CommitBranch }}
+{{`{{ .Metadata.Repository.DefaultBranch }}`}} = {{ .Metadata.Repository.DefaultBranch }}
+{{`{{ .Metadata.Template.Permissions }}`}} = {{ .Metadata.Template.Permissions }}
+{{`{{ .Metadata.Template.RelativePath }}`}} = {{ .Metadata.Template.RelativePath }}

--- a/domain/testdata/golden/metadata.txt
+++ b/domain/testdata/golden/metadata.txt
@@ -1,0 +1,8 @@
+{{ .Metadata.Repository.RootDir }} = repos/github.com/ccremer/greposync
+{{ .Metadata.Repository.FullName }} = github.com/ccremer/greposync
+{{ .Metadata.Repository.Name }} = greposync
+{{ .Metadata.Repository.Namespace }} = ccremer
+{{ .Metadata.Repository.CommitBranch }} = greposync-update
+{{ .Metadata.Repository.DefaultBranch }} = master
+{{ .Metadata.Template.Permissions }} = 0644
+{{ .Metadata.Template.RelativePath }} = testdata/golden/metadata.tpl


### PR DESCRIPTION
## Summary

* Adds a reference section which `.Metadata` variables are available in templates

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
