### PR TITLE
Fix success being reported even if repository failed

### DIFF
--- a/application/instrumentation/batchintstrumentation.go
+++ b/application/instrumentation/batchintstrumentation.go
@@ -10,5 +10,9 @@ type BatchInstrumentation interface {
 	BatchPipelineCompleted(repos []*domain.GitRepository)
 	PipelineForRepositoryStarted(repo *domain.GitRepository)
 	PipelineForRepositoryCompleted(repo *domain.GitRepository, err error)
-	NewCollectErrorHandler(repos []*domain.GitRepository, skipBroken bool) parallel.ResultHandler
+	NewCollectErrorHandler(skipBroken bool) parallel.ResultHandler
+}
+
+type InstrumentationContext interface {
+	GetRepositories() []*domain.GitRepository
 }

--- a/application/labels/main.go
+++ b/application/labels/main.go
@@ -37,10 +37,10 @@ func NewCommand(
 }
 
 func (c *Command) runCommand(_ *cli.Context) error {
-	result := pipeline.NewPipeline().WithSteps(
+	result := pipeline.NewPipeline().WithContext(c).WithSteps(
 		pipeline.NewStepFromFunc("configure infrastructure", c.configureInfrastructure),
 		pipeline.NewStepFromFunc("fetch repositories", c.fetchRepositories),
-		parallel.NewWorkerPoolStep("update labels for all repos", c.cfg.Project.Jobs, c.updateRepos(), c.instrumentation.NewCollectErrorHandler(c.repos, c.cfg.Project.SkipBroken)),
+		parallel.NewWorkerPoolStep("update labels for all repos", c.cfg.Project.Jobs, c.updateRepos(), c.instrumentation.NewCollectErrorHandler(c.cfg.Project.SkipBroken)),
 	).Run()
 	return result.Err
 }
@@ -116,4 +116,8 @@ func (c *Command) fetchRepositories(_ pipeline.Context) error {
 func (c *Command) configureInfrastructure(_ pipeline.Context) error {
 	c.appService.ConfigureInfrastructure()
 	return nil
+}
+
+func (c *Command) GetRepositories() []*domain.GitRepository {
+	return c.repos
 }

--- a/docs/modules/ROOT/examples/code/metadata.tpl
+++ b/docs/modules/ROOT/examples/code/metadata.tpl
@@ -1,8 +1,8 @@
-{{ .Metadata.Repository.RootDir }} = repos/github.com/ccremer/greposync
-{{ .Metadata.Repository.FullName }} = github.com/ccremer/greposync
-{{ .Metadata.Repository.Name }} = greposync
 {{ .Metadata.Repository.Namespace }} = ccremer
 {{ .Metadata.Repository.CommitBranch }} = greposync-update
 {{ .Metadata.Repository.DefaultBranch }} = master
-{{ .Metadata.Template.Permissions }} = 0644
+{{ .Metadata.Repository.RootDir }} = repos/github.com/ccremer/greposync
+{{ .Metadata.Repository.FullName }} = github.com/ccremer/greposync
+{{ .Metadata.Repository.Name }} = greposync
 {{ .Metadata.Template.RelativePath }} = testdata/golden/metadata.tpl
+{{ .Metadata.Template.Permissions }} = 0644

--- a/domain/testdata/golden/metadata.tpl
+++ b/domain/testdata/golden/metadata.tpl
@@ -1,8 +1,8 @@
-{{`{{ .Metadata.Repository.RootDir }}`}} = {{ .Metadata.Repository.RootDir }}
-{{`{{ .Metadata.Repository.FullName }}`}} = {{ .Metadata.Repository.FullName }}
-{{`{{ .Metadata.Repository.Name }}`}} = {{ .Metadata.Repository.Name }}
 {{`{{ .Metadata.Repository.Namespace }}`}} = {{ .Metadata.Repository.Namespace }}
 {{`{{ .Metadata.Repository.CommitBranch }}`}} = {{ .Metadata.Repository.CommitBranch }}
 {{`{{ .Metadata.Repository.DefaultBranch }}`}} = {{ .Metadata.Repository.DefaultBranch }}
-{{`{{ .Metadata.Template.Permissions }}`}} = {{ .Metadata.Template.Permissions }}
+{{`{{ .Metadata.Repository.RootDir }}`}} = {{ .Metadata.Repository.RootDir }}
+{{`{{ .Metadata.Repository.FullName }}`}} = {{ .Metadata.Repository.FullName }}
+{{`{{ .Metadata.Repository.Name }}`}} = {{ .Metadata.Repository.Name }}
 {{`{{ .Metadata.Template.RelativePath }}`}} = {{ .Metadata.Template.RelativePath }}
+{{`{{ .Metadata.Template.Permissions }}`}} = {{ .Metadata.Template.Permissions }}

--- a/domain/testdata/golden/metadata.txt
+++ b/domain/testdata/golden/metadata.txt
@@ -1,8 +1,8 @@
-{{ .Metadata.Repository.RootDir }} = repos/github.com/ccremer/greposync
-{{ .Metadata.Repository.FullName }} = github.com/ccremer/greposync
-{{ .Metadata.Repository.Name }} = greposync
 {{ .Metadata.Repository.Namespace }} = ccremer
 {{ .Metadata.Repository.CommitBranch }} = greposync-update
 {{ .Metadata.Repository.DefaultBranch }} = master
-{{ .Metadata.Template.Permissions }} = 0644
+{{ .Metadata.Repository.RootDir }} = repos/github.com/ccremer/greposync
+{{ .Metadata.Repository.FullName }} = github.com/ccremer/greposync
+{{ .Metadata.Repository.Name }} = greposync
 {{ .Metadata.Template.RelativePath }} = testdata/golden/metadata.tpl
+{{ .Metadata.Template.Permissions }} = 0644


### PR DESCRIPTION
## Summary

* Fixes a bug where successful updates were reported as failures and vice versa

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
