### PR TITLE
Fix update pipeline not pulling after cloning

### DIFF
--- a/application/update/main.go
+++ b/application/update/main.go
@@ -86,7 +86,7 @@ func (c *Command) createPipeline(r *domain.GitRepository) *pipeline.Pipeline {
 				predicate.ToStep("fetch", repoCtx.fetch(), predicate.Bool(resetRepo)),
 				predicate.ToStep("reset", repoCtx.reset(), predicate.Bool(resetRepo)),
 				predicate.ToStep("checkout branch", repoCtx.checkout(), predicate.Bool(resetRepo)),
-				predicate.ToStep("pull", repoCtx.fetch(), predicate.Bool(resetRepo)),
+				predicate.ToStep("pull", repoCtx.pull(), predicate.Bool(resetRepo)),
 			),
 
 		pipeline.NewPipeline().AddBeforeHook(logger).


### PR DESCRIPTION
## Summary

* Fixes an ugly oversight.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
