### PR TITLE
Detect if environment is interactive and hide progressbar if not

### DIFF
--- a/application/instrumentation/commonbatchinstrumentation.go
+++ b/application/instrumentation/commonbatchinstrumentation.go
@@ -29,8 +29,7 @@ func NewUpdateInstrumentation(console *ui.ColoredConsole, factory logging.Logger
 
 func (i *CommonBatchInstrumentation) BatchPipelineStarted(repos []*domain.GitRepository) {
 	i.log.Info("Update started")
-	p, _ := i.console.BatchProgressbar.WithTotal(len(repos)).Start()
-	i.console.BatchProgressbar = p
+	i.console.StartBatchUpdate(repos)
 }
 
 func (i *CommonBatchInstrumentation) BatchPipelineCompleted(repos []*domain.GitRepository) {

--- a/docs/modules/ROOT/pages/tutorials/installation.adoc
+++ b/docs/modules/ROOT/pages/tutorials/installation.adoc
@@ -90,7 +90,6 @@ include::example$code/install-download.sh[]
 ----
 gsync() {
   docker run \
-    --interactive \
     --rm \
     --user="$(id -u)" \
     --env GITHUB_TOKEN \

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/knadh/koanf v1.2.4
 	github.com/mariotoffia/goasciidoc v0.4.6
+	github.com/mattn/go-isatty v0.0.14
 	github.com/pterm/pterm v0.12.31
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -192,6 +192,8 @@ github.com/mariotoffia/goasciidoc v0.4.6 h1:2x0SL8bSrLNG2igwt9AVx9zQPE3nh/NTfDOj
 github.com/mariotoffia/goasciidoc v0.4.6/go.mod h1:mDzH5TU1OtnWBqjDAi2iVuHnxmDiu0DBnT9jDKqAHlc=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -374,6 +376,7 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210930141918-969570ce7c6c h1:ayiZ33F3u3LIXB03Y5VKNdaFO79a18Fr+SB30o/KFyw=
 golang.org/x/sys v0.0.0-20210930141918-969570ce7c6c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
## Summary

The progressbar behaves kinda weird when in non-interactive execution. It can't properly calculate the terminal width and things may look ugly.
Thus we simply try to hide it 🤷 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
