### PR TITLE
Switch container base image from Alpine to Debian

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.*
+*
+!gsync
+!docker/entrypoint.sh

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,14 +26,16 @@ checksum:
   name_template: "checksums.txt"
 
 snapshot:
-  name_template: "{{ .Tag }}-snapshot"
+  name_template: "{{ incpatch .Version }}-snapshot"
 
 signs:
 - artifacts: checksum
   args: ["-u", "4E74BD9589869F6CB8A73D279533207D7E3143FC", "--output", "${signature}", "--detach-sign", "${artifact}"]
 
 dockers:
-- image_templates:
+- extra_files:
+  - docker/entrypoint.sh
+  image_templates:
   - "ghcr.io/ccremer/greposync:v{{ .Version }}"
 
     # For prereleases, updating `latest` and the floating tags of the major version does not make sense.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM docker.io/library/alpine:3.14 as runtime
+FROM docker.io/library/debian:11-slim as runtime
 
-ENTRYPOINT ["gsync"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh", "gsync"]
 
 RUN \
-  apk add --no-cache curl bash git openssh
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    curl bash git openssh-client libnss-wrapper && \
+  rm -rf /var/lib/apt/lists/*
 
+COPY docker/entrypoint.sh /usr/local/bin/
 COPY gsync /usr/bin/
 USER 1000:0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libnss_wrapper.so
+export NSS_WRAPPER_PASSWD=/tmp/passwd
+export NSS_WRAPPER_GROUP=/etc/group
+
+if ! whoami &> /dev/null; then
+  echo "git:x:$(id -u):$(id -g):Git user:${HOME}:/sbin/nologin" > "${NSS_WRAPPER_PASSWD}"
+fi
+
+exec "$@"

--- a/docs/modules/ROOT/pages/tutorials/installation.adoc
+++ b/docs/modules/ROOT/pages/tutorials/installation.adoc
@@ -91,10 +91,10 @@ include::example$code/install-download.sh[]
 gsync() {
   docker run \
     --interactive \
-    --tty \
     --rm \
     --user="$(id -u)" \
     --env GITHUB_TOKEN \
+    --env HOME=/app \
     --env SSH_AUTH_SOCK=/tmp/ssh_agent.sock \
     --volume "$\{SSH_AUTH_SOCK}:/tmp/ssh_agent.sock" \
     --volume "$\{HOME}/.ssh/config:/app/.ssh/config:ro" \
@@ -106,3 +106,11 @@ gsync() {
     $*
 }
 ----
++
+[NOTE]
+====
+* If any of the `~/.ssh` files or `~/.gitconfig` don't exist, they are created as directories!
+  This won't work, so please ensure that these files exist before.
+* `git clone` inside the container fails if using git+ssh URLs when the SSH config files have not the correct permissions.
+  Ensure that they are at least `0644` or lower.
+====


### PR DESCRIPTION
## Summary

Git clone fails if the repository URLs contain the SSH scheme, since SSH would then look up who is the current user in `/etc/passwd`. With a dynamic user id passed in via docker CLI flags (e.g. `--user $(id -u)`) then this user doesn't exist and SSH aborts, causing Git to also abort in cascading manner.

To workaround this, we could either:
* Keep alpine image, but make an entrypoint script that edits `/etc/passwd` at startup. Not great from a security PoV.
* Use libnss-wrapper library in which we can dynamically add users and groups without touching `/etc/passwd`. But that package is not available in Alpine, so we'd have to switch to debian/ubuntu base image.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
