### PR TITLE
Randomize order of repositories to update

### DIFF
--- a/docs/modules/ROOT/pages/tutorials/getting-started.adoc
+++ b/docs/modules/ROOT/pages/tutorials/getting-started.adoc
@@ -101,8 +101,9 @@ gsync update --dry-run=commit
 +
 [NOTE]
 ====
-There is a warning about a missing `.sync.yml`.
-We will add this file in a later step.
+* There is a warning about a missing `.sync.yml`.
+  We will add this file in a later step.
+* The order of repositories being updated is randomized each time.
 ====
 
 . Inspect the directory structure

--- a/infrastructure/repositorystore/repository_store.go
+++ b/infrastructure/repositorystore/repository_store.go
@@ -2,11 +2,13 @@ package repositorystore
 
 import (
 	"fmt"
+	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/ccremer/greposync/domain"
 	"github.com/knadh/koanf"
@@ -93,6 +95,11 @@ func (s *RepositoryStore) FetchGitRepositories() ([]*domain.GitRepository, error
 		}
 		list = append(list, gitRepository)
 	}
+	// Shuffle the list to avoid rate limits to be applied always at the same "spot", if any.
+	rand.Seed(time.Now().Unix())
+	rand.Shuffle(len(list), func(i, j int) {
+		list[i], list[j] = list[j], list[i]
+	})
 	return list, nil
 }
 


### PR DESCRIPTION
## Summary

With large number of repositories, certain Git hosting services like GitHub may start rate limiting.
There's not much we can do.
However, by randomizing the list we can avoid this limit being reached always at the same spot.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
