### PR TITLE
Support displaying Git diff of unstaged changes

### DIFF
--- a/application/update/command.go
+++ b/application/update/command.go
@@ -20,7 +20,7 @@ func (c *Command) createCliCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:    dryRunFlagName,
 				Aliases: []string{"d"},
-				Usage:   "Select a dry run mode. Allowed values: offline (do not run any Git commands), commit (commit, but don't push), push (push, but don't touch PRs)",
+				Usage:   "Select a dry run mode. Allowed values: offline (do not run any Git commands except initial clone), commit (commit, but don't push), push (push, but don't touch PRs)",
 			},
 			&cli.BoolFlag{
 				Name:  amendFlagName,
@@ -36,7 +36,7 @@ func (c *Command) createCliCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  showDiffFlagName,
-				Usage: "Show the Git Diff for each repository after updating.",
+				Usage: "Show the Git Diff for each repository after committing. In --dry-run=offline mode the diff is showed for unstaged changes.",
 			},
 		),
 	}

--- a/application/update/context.go
+++ b/application/update/context.go
@@ -49,7 +49,9 @@ func (c *pipelineContext) commit() pipeline.ActionFunc {
 
 func (c *pipelineContext) diff() pipeline.ActionFunc {
 	return func(_ pipeline.Context) pipeline.Result {
-		diff, err := c.appService.repoStore.Diff(c.repo)
+		diff, err := c.appService.repoStore.Diff(c.repo, domain.DiffOptions{
+			WorkDirToHEAD: c.appService.cfg.Git.SkipCommit, // If we don't commit, show the unstaged changes
+		})
 		if err != nil {
 			return pipeline.Result{Err: err}
 		}

--- a/application/update/main.go
+++ b/application/update/main.go
@@ -100,10 +100,10 @@ func (c *Command) createPipeline(r *domain.GitRepository) *pipeline.Pipeline {
 			WithNestedSteps("commit changes",
 				pipeline.NewStep("add", repoCtx.add()),
 				pipeline.NewStep("commit", repoCtx.commit()),
-				predicate.ToStep("show diff", repoCtx.diff(), predicate.Bool(showDiff)),
 			),
 			predicate.And(predicate.Bool(enabledCommits), repoCtx.isDirty())),
 
+		predicate.ToStep("show diff", repoCtx.diff(), predicate.Bool(showDiff)),
 		predicate.ToStep("push changes", repoCtx.push(), predicate.And(predicate.Bool(enabledPush), repoCtx.hasCommits())),
 		predicate.ToStep("find existing pull request", repoCtx.fetchPullRequest(), predicate.Bool(createPR)),
 		predicate.ToStep("ensure pull request", repoCtx.ensurePullRequest(), predicate.And(repoCtx.hasCommits(), predicate.Bool(createPR))),

--- a/docs/modules/developer-guide/pages/ref-domain.adoc
+++ b/docs/modules/developer-guide/pages/ref-domain.adoc
@@ -53,7 +53,7 @@ type GitRepositoryStore interface {
     Pull(repository *GitRepository) error
     Add(repository *GitRepository) error
     Commit(repository *GitRepository, options CommitOptions) error
-    Diff(repository *GitRepository) (string, error)
+    Diff(repository *GitRepository, options DiffOptions) (string, error)
     Push(repository *GitRepository, options PushOptions) error
 }
 ----
@@ -124,10 +124,10 @@ Commit records changes in the repository.
 .Diff
 [source, go]
 ----
-func Diff(repository *GitRepository) (string, error)
+func Diff(repository *GitRepository, options DiffOptions) (string, error)
 ----
-Diff returns a `patch`-compatible diff between HEAD and previous commit as string.
-The diff may be empty.
+Diff returns a `patch`-compatible diff using given options.
+The diff may be empty without error.
 
 .Push
 [source, go]
@@ -514,6 +514,25 @@ PushOptions contains settings to influence the GitRepositoryStore.Push action.
 
 Force::
 Force overwrites the remote state when pushing.
+
+
+
+
+'''
+
+=== DiffOptions
+[source, go]
+----
+type DiffOptions struct {
+    WorkDirToHEAD    bool
+}
+----
+
+DiffOptions contains settings to influence the GitRepositoryStore.Diff action.
+
+WorkDirToHEAD::
+WorkDirToHEAD retrieves a diff between Working Directory and latest commit.
+If false, a diff between HEAD and previous commit (HEAD~1) is retrieved.
 
 
 

--- a/domain/gitrepository_store.go
+++ b/domain/gitrepository_store.go
@@ -25,9 +25,9 @@ type GitRepositoryStore interface {
 	Add(repository *GitRepository) error
 	// Commit records changes in the repository.
 	Commit(repository *GitRepository, options CommitOptions) error
-	// Diff returns a `patch`-compatible diff between HEAD and previous commit as string.
-	// The diff may be empty.
-	Diff(repository *GitRepository) (string, error)
+	// Diff returns a `patch`-compatible diff using given options.
+	// The diff may be empty without error.
+	Diff(repository *GitRepository, options DiffOptions) (string, error)
 
 	// Push updates remote refs.
 	Push(repository *GitRepository, options PushOptions) error
@@ -45,4 +45,11 @@ type CommitOptions struct {
 type PushOptions struct {
 	// Force overwrites the remote state when pushing.
 	Force bool
+}
+
+// DiffOptions contains settings to influence the GitRepositoryStore.Diff action.
+type DiffOptions struct {
+	// WorkDirToHEAD retrieves a diff between Working Directory and latest commit.
+	// If false, a diff between HEAD and previous commit (HEAD~1) is retrieved.
+	WorkDirToHEAD bool
 }

--- a/infrastructure/repositorystore/commit.go
+++ b/infrastructure/repositorystore/commit.go
@@ -51,8 +51,12 @@ func (s *RepositoryStore) Add(repository *domain.GitRepository) error {
 	return nil
 }
 
-func (s *RepositoryStore) Diff(repository *domain.GitRepository) (string, error) {
-	out, stderr, err := execGitCommand(repository.RootDir, []string{"diff", "HEAD~1"})
+func (s *RepositoryStore) Diff(repository *domain.GitRepository, options domain.DiffOptions) (string, error) {
+	args := []string{"diff", "HEAD~1"}
+	if options.WorkDirToHEAD {
+		args = []string{"diff", "HEAD"}
+	}
+	out, stderr, err := execGitCommand(repository.RootDir, args)
 	if err != nil {
 		if strings.Contains(stderr, "ambiguous argument 'HEAD~1': unknown revision or path not in the working tree.") {
 			s.instrumentation.logInfo(repository, "This is the first commit, no diff available.")

--- a/infrastructure/valuestore/specialflags_test.go
+++ b/infrastructure/valuestore/specialflags_test.go
@@ -46,7 +46,7 @@ var specialFlagsCases = map[string]struct {
 	},
 }
 
-func TestKoanfValueStore_FetchFilesToDelete(t *testing.T) {
+func TestMapStore_FetchFilesToDelete(t *testing.T) {
 	tests := map[string]struct {
 		givenSyncFile string
 		expectedFiles []domain.Path
@@ -81,7 +81,7 @@ func TestKoanfValueStore_FetchFilesToDelete(t *testing.T) {
 	}
 }
 
-func TestKoanfValueStore_loadBooleanFlag(t *testing.T) {
+func TestMapStore_loadBooleanFlag(t *testing.T) {
 	for _, flagName := range []string{"delete", "unmanaged"} {
 		for name, tt := range specialFlagsCases {
 			t.Run(name+"_With_"+flagName, func(t *testing.T) {
@@ -101,7 +101,7 @@ func TestKoanfValueStore_loadBooleanFlag(t *testing.T) {
 	}
 }
 
-func TestKoanfValueStore_FetchTargetPath(t *testing.T) {
+func TestMapStore_FetchTargetPath(t *testing.T) {
 	for name, tt := range specialFlagsCases {
 		t.Run(name, func(t *testing.T) {
 			s := NewMapStore(nil)


### PR DESCRIPTION
## Summary

It's now possible to show a Git diff for each repo even if not committed.
This should improve UX in offline mode, like testing out local template results.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
