### PR TITLE
Add force push CLI flag

### DIFF
--- a/application/update/command.go
+++ b/application/update/command.go
@@ -24,7 +24,11 @@ func (c *Command) createCliCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  amendFlagName,
-				Usage: "Amend previous commit.",
+				Usage: "Amend previous commit. Requires --git-forcePush",
+			},
+			&cli.BoolFlag{
+				Name:  forcePushFlagName,
+				Usage: "If push is enabled, push forcefully.",
 			},
 			&cli.BoolFlag{
 				Name:  prCreateFlagName,

--- a/application/update/main.go
+++ b/application/update/main.go
@@ -12,11 +12,12 @@ import (
 )
 
 const (
-	dryRunFlagName   = "dry-run"
-	prCreateFlagName = "pr-create"
-	prBodyFlagName   = "pr-bodyTemplate"
-	amendFlagName    = "git-amend"
-	showDiffFlagName = "log-showDiff"
+	dryRunFlagName    = "dry-run"
+	prCreateFlagName  = "pr-create"
+	prBodyFlagName    = "pr-bodyTemplate"
+	amendFlagName     = "git-amend"
+	forcePushFlagName = "git-forcePush"
+	showDiffFlagName  = "log-showDiff"
 )
 
 type (


### PR DESCRIPTION
## Summary

Allows pushing branches with `--git-forcePush` in addition to setting in greposync.yml.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
