### PR TITLE
Fix diffprinter messing with progressbar

### DIFF
--- a/infrastructure/ui/diffprinter.go
+++ b/infrastructure/ui/diffprinter.go
@@ -1,8 +1,6 @@
 package ui
 
 import (
-	"io"
-	"os"
 	"strings"
 
 	"github.com/pterm/pterm"
@@ -17,14 +15,12 @@ type DiffPrinter interface {
 
 // ConsoleDiffPrinter prints a colored diff to console.
 type ConsoleDiffPrinter struct {
-	writer io.Writer
 	header *pterm.HeaderPrinter
 }
 
 // NewConsoleDiffPrinter returns a new instance.
 func NewConsoleDiffPrinter() *ConsoleDiffPrinter {
 	return &ConsoleDiffPrinter{
-		writer: os.Stdout,
 		header: pterm.DefaultHeader.WithBackgroundStyle(pterm.NewStyle(pterm.BgMagenta)).WithMargin(15),
 	}
 }
@@ -32,23 +28,23 @@ func NewConsoleDiffPrinter() *ConsoleDiffPrinter {
 // PrintDiff implements DiffPrinter.
 // The prefix is used to print a header before actually printing the diff.
 func (c *ConsoleDiffPrinter) PrintDiff(prefix, diff string) {
-	if prefix != "" {
-		bytes := c.header.Sprintln(prefix)
-		_, _ = c.writer.Write([]byte(bytes))
-	}
 	lines := strings.Split(diff, "\n")
+	if diff == "" {
+		// no diff to print
+		return
+	}
+	if prefix != "" {
+		c.header.Println(prefix)
+	}
 	for _, line := range lines {
 		if strings.HasPrefix(line, "-") {
-			bytes := pterm.FgRed.Sprintln(line)
-			_, _ = c.writer.Write([]byte(bytes))
+			pterm.FgRed.Println(line)
 			continue
 		}
 		if strings.HasPrefix(line, "+") {
-			bytes := pterm.FgGreen.Sprintln(line)
-			_, _ = c.writer.Write([]byte(bytes))
+			pterm.FgGreen.Println(line)
 			continue
 		}
-		bytes := pterm.Sprintln(line)
-		_, _ = c.writer.Write([]byte(bytes))
+		pterm.Println(line)
 	}
 }

--- a/infrastructure/ui/diffprinter_test.go
+++ b/infrastructure/ui/diffprinter_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/gookit/color"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,13 +19,17 @@ func TestConsoleDiffPrinter_PrintDiff(t *testing.T) {
 			givenDiff:   "normal line\n+added line\n-removed line",
 			expectedOut: "\x1b[0m\x1b[0m\nnormal line\n\x1b[32m+added line\x1b[0m\n\x1b[32m\x1b[0m\x1b[31m-removed line\x1b[0m\n\x1b[31m\x1b[0m",
 		},
+		"GivenNoDiff_WhenDiffEmpty_ThenExpectNoOutput": {
+			givenPrefix: "Prefix",
+			givenDiff:   "",
+			expectedOut: "",
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := NewConsoleDiffPrinter()
 			buf := &bytes.Buffer{}
-			c.writer = buf
-
+			color.SetOutput(buf)
 			c.PrintDiff(tt.givenPrefix, tt.givenDiff)
 
 			assert.Contains(t, buf.String(), tt.expectedOut)


### PR DESCRIPTION


## Summary

If the diff printer directly prints to Stdout, the progressbar doesn't render properly anymore.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
