### PR TITLE
Cleaning undesired files now also include template files

### DIFF
--- a/application/test/pipeline.go
+++ b/application/test/pipeline.go
@@ -45,8 +45,9 @@ func (c *updatePipeline) createOutputDir(_ context.Context) error {
 
 func (c *updatePipeline) cleanupUnwantedFiles(_ context.Context) error {
 	err := c.appService.cleanupService.CleanupUnwantedFiles(domain.CleanupPipeline{
-		Repository: c.repo,
-		ValueStore: c.appService.valueStore,
+		Repository:    c.repo,
+		ValueStore:    c.appService.valueStore,
+		TemplateStore: c.appService.templateStore,
 	})
 	return err
 }

--- a/application/update/pipeline.go
+++ b/application/update/pipeline.go
@@ -76,8 +76,9 @@ func (c *updatePipeline) renderTemplates(_ context.Context) error {
 
 func (c *updatePipeline) cleanupUnwantedFiles(_ context.Context) error {
 	err := c.appService.cleanupService.CleanupUnwantedFiles(domain.CleanupPipeline{
-		Repository: c.repo,
-		ValueStore: c.appService.valueStore,
+		Repository:    c.repo,
+		ValueStore:    c.appService.valueStore,
+		TemplateStore: c.appService.templateStore,
 	})
 	return err
 }

--- a/docs/modules/ROOT/pages/references/sync-config.adoc
+++ b/docs/modules/ROOT/pages/references/sync-config.adoc
@@ -67,12 +67,13 @@ dir/subdir/file:
 
 `delete: true`::
 When this flag is set, the target file is being deleted.
-It is not rendered at all.
+If this flag is applied to directories or `:globals`, then every known and affected template file is deleted as well.
 
 [TIP]
 ====
 * Use this flag in `config_defaults.yml` to cleanup files that aren't needed in the managed repositories anymore.
-* Use this flag in `.sync.file` to tell greposync to not create certain files.
+* Use this flag in `.sync.file` on a single file name to tell greposync to not create single files.
+* Use this flag in `.sync.file` on a directory name or in `:globals` to tell greposync to not create multiple files.
 ====
 
 `unmanaged: true`::

--- a/docs/modules/developer-guide/pages/ref-domain.adoc
+++ b/docs/modules/developer-guide/pages/ref-domain.adoc
@@ -326,7 +326,7 @@ type ValueStore interface {
     FetchValuesForTemplate(template *Template, repository *GitRepository) (Values, error)
     FetchUnmanagedFlag(template *Template, repository *GitRepository) (bool, error)
     FetchTargetPath(template *Template, repository *GitRepository) (Path, error)
-    FetchFilesToDelete(repository *GitRepository) ([]Path, error)
+    FetchFilesToDelete(repository *GitRepository, templates []*Template) ([]Path, error)
 }
 ----
 
@@ -360,7 +360,7 @@ An empty string indicates that there is no alternative path configured.
 .FetchFilesToDelete
 [source, go]
 ----
-func FetchFilesToDelete(repository *GitRepository) ([]Path, error)
+func FetchFilesToDelete(repository *GitRepository, templates []*Template) ([]Path, error)
 ----
 FetchFilesToDelete returns a slice of Path that should be deleted in the Git repository.
 The paths are relative to the Git root directory.
@@ -399,10 +399,14 @@ func (s *CleanupService) CleanupUnwantedFiles(pipe CleanupPipeline) error
 [source, go]
 ----
 type CleanupPipeline struct {
-    Repository    *GitRepository
-    ValueStore    ValueStore
+    Repository       *GitRepository
+    ValueStore       ValueStore
+    TemplateStore    TemplateStore
 }
 ----
+
+
+
 
 
 
@@ -760,7 +764,7 @@ RenderService is a domain service that helps rendering templates.
 func (s *RenderService) RenderTemplates(ctx RenderContext) error
 ----
 
-RenderTemplates loads the Templates and renders them in the GitRepository.RootDir of the given RenderContext.Repository.
+RenderTemplates loads the TemplateStore and renders them in the GitRepository.RootDir of the given RenderContext.Repository.
 
 
 '''
@@ -1010,6 +1014,14 @@ func (p Path) String() string
 ----
 
 String returns a string representation of itself.
+
+.IsInSlice
+[source, go]
+----
+func (p Path) IsInSlice(paths []Path) bool
+----
+
+IsInSlice returns true if p is in the given slice, false otherwise.
 
 
 '''
@@ -1276,6 +1288,7 @@ func NewCleanupService(
 
 
 
+
 === NewGitRepository
 [source, go]
 ----
@@ -1326,6 +1339,7 @@ func NewFilePath(elems ...string) Path
 
 NewFilePath constructs a new Path joined by the given elements.
 Paths are joined with filepath.Join.
+
 
 
 

--- a/domain/cleanup_service.go
+++ b/domain/cleanup_service.go
@@ -12,10 +12,13 @@ type CleanupService struct {
 }
 
 type CleanupPipeline struct {
-	Repository *GitRepository
-	ValueStore ValueStore
+	Repository    *GitRepository
+	ValueStore    ValueStore
+	TemplateStore TemplateStore
 
-	files           []Path
+	files     []Path
+	templates []*Template
+
 	instrumentation CleanupServiceInstrumentation
 }
 
@@ -31,34 +34,42 @@ func (s *CleanupService) CleanupUnwantedFiles(pipe CleanupPipeline) error {
 	pipe.instrumentation = s.instrumentation.WithRepository(pipe.Repository)
 	result := pipeline.NewPipeline().WithSteps(
 		pipeline.NewStepFromFunc("preflight check", pipe.preFlightCheck),
+		pipeline.NewStepFromFunc("load templates", pipe.loadTemplates),
 		pipeline.NewStepFromFunc("load files", pipe.loadFiles),
 		pipeline.NewStepFromFunc("delete files", pipe.deleteFiles),
 	).Run()
 	return result.Err()
 }
 
-func (ctx *CleanupPipeline) preFlightCheck(_ context.Context) error {
+func (p *CleanupPipeline) preFlightCheck(_ context.Context) error {
 	err := firstOf(
-		checkIfArgumentNil(ctx.Repository, "Repository"),
-		checkIfArgumentNil(ctx.ValueStore, "ValueStore"),
+		checkIfArgumentNil(p.Repository, "Repository"),
+		checkIfArgumentNil(p.ValueStore, "ValueStore"),
+		checkIfArgumentNil(p.TemplateStore, "TemplateStore"),
 	)
 	return err
 }
 
-func (ctx *CleanupPipeline) loadFiles(_ context.Context) error {
-	files, err := ctx.ValueStore.FetchFilesToDelete(ctx.Repository)
-	ctx.files = files
-	return ctx.instrumentation.FetchedFilesToDelete(err, files)
+func (p *CleanupPipeline) loadTemplates(_ context.Context) error {
+	templates, err := p.TemplateStore.FetchTemplates()
+	p.templates = templates
+	return err
 }
 
-func (ctx *CleanupPipeline) deleteFiles(_ context.Context) error {
-	for _, file := range ctx.files {
-		absoluteFile := ctx.Repository.RootDir.Join(file)
+func (p *CleanupPipeline) loadFiles(_ context.Context) error {
+	files, err := p.ValueStore.FetchFilesToDelete(p.Repository, p.templates)
+	p.files = files
+	return p.instrumentation.FetchedFilesToDelete(err, files)
+}
+
+func (p *CleanupPipeline) deleteFiles(_ context.Context) error {
+	for _, file := range p.files {
+		absoluteFile := p.Repository.RootDir.Join(file)
 		if absoluteFile.FileExists() {
 			if err := os.Remove(absoluteFile.String()); hasFailed(err) {
 				return err
 			}
-			ctx.instrumentation.DeletedFile(absoluteFile)
+			p.instrumentation.DeletedFile(absoluteFile)
 		}
 	}
 	return nil

--- a/domain/path.go
+++ b/domain/path.go
@@ -65,3 +65,13 @@ func (p Path) Delete() {
 func (p Path) String() string {
 	return string(p)
 }
+
+// IsInSlice returns true if p is in the given slice, false otherwise.
+func (p Path) IsInSlice(paths []Path) bool {
+	for i := 0; i < len(paths); i++ {
+		if paths[i] == p {
+			return true
+		}
+	}
+	return false
+}

--- a/domain/path_test.go
+++ b/domain/path_test.go
@@ -121,3 +121,23 @@ func TestPath_Join(t *testing.T) {
 		})
 	}
 }
+
+func TestPath_IsInSlice(t *testing.T) {
+	givenPath := NewPath("path")
+	tests := map[string]struct {
+		givenSlice     []Path
+		expectedResult bool
+	}{
+		"GivenNil_ThenExpectFalse":                       {givenSlice: nil},
+		"GivenEmptySlice_ThenExpectFalse":                {givenSlice: []Path{}},
+		"GivenSamePath_ThenExpectTrue":                   {givenSlice: []Path{"path"}, expectedResult: true},
+		"GivenAnotherPath_ThenExpectFalse":               {givenSlice: []Path{"another"}},
+		"GivenMultiplePaths_WhenSamePath_ThenExpectTrue": {givenSlice: []Path{"another", "path"}, expectedResult: true},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			result := givenPath.IsInSlice(tt.givenSlice)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}

--- a/domain/render_service.go
+++ b/domain/render_service.go
@@ -31,7 +31,7 @@ func NewRenderService(instrumentation RenderServiceInstrumentation) *RenderServi
 	}
 }
 
-// RenderTemplates loads the Templates and renders them in the GitRepository.RootDir of the given RenderContext.Repository.
+// RenderTemplates loads the TemplateStore and renders them in the GitRepository.RootDir of the given RenderContext.Repository.
 func (s *RenderService) RenderTemplates(ctx RenderContext) error {
 	ctx.instrumentation = s.instrumentation.WithRepository(ctx.Repository)
 	result := pipeline.NewPipeline().WithSteps(

--- a/domain/value_store.go
+++ b/domain/value_store.go
@@ -14,5 +14,5 @@ type ValueStore interface {
 	FetchTargetPath(template *Template, repository *GitRepository) (Path, error)
 	// FetchFilesToDelete returns a slice of Path that should be deleted in the Git repository.
 	// The paths are relative to the Git root directory.
-	FetchFilesToDelete(repository *GitRepository) ([]Path, error)
+	FetchFilesToDelete(repository *GitRepository, templates []*Template) ([]Path, error)
 }

--- a/infrastructure/valuestore/koanfstore.go
+++ b/infrastructure/valuestore/koanfstore.go
@@ -32,9 +32,9 @@ func NewKoanfStore(instrumentation *ValueStoreInstrumentation) *KoanfStore {
 }
 
 // FetchValuesForTemplate implements domain.ValueStore.
-func (s *KoanfStore) FetchValuesForTemplate(template *domain.Template, config *domain.GitRepository) (domain.Values, error) {
+func (s *KoanfStore) FetchValuesForTemplate(template *domain.Template, repository *domain.GitRepository) (domain.Values, error) {
 	s.loadGlobals()
-	repoKoanf, err := s.prepareRepoKoanf(config)
+	repoKoanf, err := s.prepareRepoKoanf(repository)
 	if err != nil {
 		return domain.Values{}, err
 	}
@@ -42,9 +42,9 @@ func (s *KoanfStore) FetchValuesForTemplate(template *domain.Template, config *d
 }
 
 // FetchUnmanagedFlag implements domain.ValueStore.
-func (s *KoanfStore) FetchUnmanagedFlag(template *domain.Template, config *domain.GitRepository) (bool, error) {
+func (s *KoanfStore) FetchUnmanagedFlag(template *domain.Template, repository *domain.GitRepository) (bool, error) {
 	s.loadGlobals()
-	repoKoanf, err := s.prepareRepoKoanf(config)
+	repoKoanf, err := s.prepareRepoKoanf(repository)
 	if err != nil {
 		return false, err
 	}
@@ -52,9 +52,9 @@ func (s *KoanfStore) FetchUnmanagedFlag(template *domain.Template, config *domai
 }
 
 // FetchTargetPath implements domain.ValueStore.
-func (s *KoanfStore) FetchTargetPath(template *domain.Template, config *domain.GitRepository) (domain.Path, error) {
+func (s *KoanfStore) FetchTargetPath(template *domain.Template, repository *domain.GitRepository) (domain.Path, error) {
 	s.loadGlobals()
-	repoKoanf, err := s.prepareRepoKoanf(config)
+	repoKoanf, err := s.prepareRepoKoanf(repository)
 	if err != nil {
 		return "", err
 	}
@@ -62,13 +62,13 @@ func (s *KoanfStore) FetchTargetPath(template *domain.Template, config *domain.G
 }
 
 // FetchFilesToDelete implements domain.ValueStore.
-func (s *KoanfStore) FetchFilesToDelete(config *domain.GitRepository) ([]domain.Path, error) {
+func (s *KoanfStore) FetchFilesToDelete(repository *domain.GitRepository, templates []*domain.Template) ([]domain.Path, error) {
 	s.loadGlobals()
-	repoKoanf, err := s.prepareRepoKoanf(config)
+	repoKoanf, err := s.prepareRepoKoanf(repository)
 	if err != nil {
 		return []domain.Path{}, err
 	}
-	return s.loadFilesToDelete(repoKoanf)
+	return s.loadFilesToDelete(repoKoanf, templates)
 }
 
 func (s *KoanfStore) prepareRepoKoanf(repository *domain.GitRepository) (*koanf.Koanf, error) {

--- a/infrastructure/valuestore/specialflags.go
+++ b/infrastructure/valuestore/specialflags.go
@@ -9,9 +9,10 @@ import (
 	"github.com/knadh/koanf"
 )
 
-func (s *KoanfStore) loadFilesToDelete(repoConfig *koanf.Koanf) ([]domain.Path, error) {
+func (s *KoanfStore) loadFilesToDelete(repoConfig *koanf.Koanf, templates []*domain.Template) ([]domain.Path, error) {
 	filePaths := make([]domain.Path, 0)
-	// Go through all top-level keys, which are the file names
+	// Go through all top-level keys, which are the file names.
+	// We do this because the list of templates might not contain the desired file name to delete anymore.
 	for filePath, _ := range repoConfig.Raw() {
 		// If the filename is already handled by the template renderer, ignore it.
 		// Otherwise, add files that have deletion flag, but ignore directories
@@ -26,8 +27,18 @@ func (s *KoanfStore) loadFilesToDelete(repoConfig *koanf.Koanf) ([]domain.Path, 
 		if errors.Is(err, domain.ErrKeyNotFound) {
 			continue
 		}
-		if del {
-			filePaths = append(filePaths, domain.Path(filePath))
+		p := domain.Path(filePath)
+		if del && !p.IsInSlice(filePaths) {
+			filePaths = append(filePaths, p)
+		}
+	}
+	for _, template := range templates {
+		del, err := s.loadBooleanFlag(repoConfig, template.CleanPath().String(), "delete")
+		if errors.Is(err, domain.ErrKeyNotFound) {
+			continue
+		}
+		if del && !template.RelativePath.IsInSlice(filePaths) {
+			filePaths = append(filePaths, template.RelativePath)
 		}
 	}
 	return filePaths, nil


### PR DESCRIPTION

## Summary

Previously, only explicitly listed files in .sync.yml are cleaned that have the delete=true flag.
Now, relative template filenames that would also get delete=true via hierarchy are included in the file deletion list.

For example, `:globals.delete=true` will now delete every known template file.
Similarily, `subdir/.delete=true` will now delete every known template file that would be rendered in `subdir/`.

This way, you don't need to specify every single file to be deleted.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
