### PR TITLE
Create subfolders first when running in test mode

### DIFF
--- a/domain/render_service.go
+++ b/domain/render_service.go
@@ -3,6 +3,8 @@ package domain
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 
 	pipeline "github.com/ccremer/go-command-pipeline"
 	"golang.org/x/sys/unix"
@@ -89,7 +91,13 @@ func (ctx *RenderContext) renderTemplate(template *Template) error {
 		targetPath = alternativePath
 	}
 
-	err = result.WriteToFile(ctx.Repository.RootDir.Join(targetPath), template.FilePermissions)
+	actualFile := ctx.Repository.RootDir.Join(targetPath)
+	err = os.MkdirAll(filepath.Dir(actualFile.String()), 0775)
+	if err != nil {
+		return err
+	}
+
+	err = result.WriteToFile(actualFile, template.FilePermissions)
 	return ctx.instrumentation.WrittenRenderResultToFile(template, targetPath, err)
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where files in subfolder for test cases where not being created if parent dir doesn't yet exist.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
