### PR TITLE
Make git base URL configurable

### DIFF
--- a/application/flags/flags.go
+++ b/application/flags/flags.go
@@ -126,6 +126,13 @@ func NewGitCommitMessageFlag(dst *string) *altsrc.StringFlag {
 	})
 }
 
+func NewGitBaseURLFlag(dst *string) *altsrc.StringFlag {
+	return altsrc.NewStringFlag(&cli.StringFlag{Name: "git.base", EnvVars: Prefixed("GIT_BASE"),
+		Usage: "Git base URL.",
+		Value: "git@github.com:", Destination: dst,
+	})
+}
+
 //// PR Flags
 
 func NewPRCreateFlag(dst *bool) *altsrc.BoolFlag {

--- a/application/update/command.go
+++ b/application/update/command.go
@@ -28,6 +28,7 @@ func (c *Command) createCliCommand() *cli.Command {
 		flags.NewGitCommitBranchFlag(&c.appService.repoStore.CommitBranch),
 		flags.NewGitDefaultNamespaceFlag(&c.appService.repoStore.DefaultNamespace),
 		flags.NewGitCommitMessageFlag(&c.cfg.Git.CommitMessage),
+		flags.NewGitBaseURLFlag(&c.appService.repoStore.BaseURL),
 
 		flags.NewPRCreateFlag(&c.cfg.PullRequest.Create),
 		flags.NewPRBodyFlag(&c.cfg.PullRequest.BodyTemplate),

--- a/docs/modules/ROOT/examples/config.yaml
+++ b/docs/modules/ROOT/examples/config.yaml
@@ -1,4 +1,5 @@
 git:
+  base: 'git@github.com:'
   commitBranch: greposync-update
   commitMessage: Update from greposync
   defaultNamespace: github.com

--- a/docs/modules/ROOT/examples/help/update.txt
+++ b/docs/modules/ROOT/examples/help/update.txt
@@ -8,6 +8,7 @@ OPTIONS:
    --dry-run value               Select a dry run mode. Allowed values: offline (do not run any Git commands except initial clone), commit (commit, but don't push), push (push, but don't touch PRs) [$G_DRYRUN]
    --exclude value               Excludes repositories from updating that match the given filter (regex). Repositories matching both include and exclude filter are still excluded. [$G_EXCLUDE]
    --git.amend                   Amend previous commit. Requires --git.forcePush. (default: false) [$G_GIT_AMEND]
+   --git.base value              Git base URL. (default: "git@github.com:") [$G_GIT_BASE]
    --git.commitBranch value      The branch name to create, switch to and commit locally. (default: "greposync-update") [$G_GIT_COMMIT_BRANCH]
    --git.commitMessage value     The commit message when committing an update. (default: "Update from greposync") [$G_GIT_COMMIT_MSG]
    --git.defaultNamespace value  The repository owner without the repository name. This is often a user or organization name in GitHub.com or GitLab.com. (default: "github.com") [$G_GIT_DEFAULT_NS]

--- a/generate.go
+++ b/generate.go
@@ -43,6 +43,7 @@ func createExampleConfig() {
 		flags.NewGitCommitBranchFlag(nil),
 		flags.NewGitDefaultNamespaceFlag(nil),
 		flags.NewGitForcePushFlag(nil),
+		flags.NewGitBaseURLFlag(nil),
 
 		flags.NewShowDiffFlag(nil),
 		flags.NewShowLogFlag(nil),

--- a/infrastructure/repositorystore/repository_store.go
+++ b/infrastructure/repositorystore/repository_store.go
@@ -32,6 +32,7 @@ type StoreConfig struct {
 	ParentDir        string
 	DefaultNamespace string
 	CommitBranch     string
+	BaseURL          string
 
 	IncludeFilter string
 	ExcludeFilter string
@@ -64,7 +65,6 @@ func (s *RepositoryStore) FetchGitRepositories() ([]*domain.GitRepository, error
 	if err := s.k.Unmarshal("repositories", &m); err != nil {
 		return nil, err
 	}
-	gitBase := "git@github.com:"
 
 	includeRegex, excludeRegex, err := compileRegex(s.IncludeFilter, s.ExcludeFilter)
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *RepositoryStore) FetchGitRepositories() ([]*domain.GitRepository, error
 	}
 
 	for _, repo := range m {
-		u, err := parseUrl(repo, gitBase, s.DefaultNamespace)
+		u, err := parseUrl(repo, s.BaseURL, s.DefaultNamespace)
 		if err != nil {
 			return list, err
 		}


### PR DESCRIPTION
## Summary

* Adds `--git.base` flag (or in YAML: `git.base`) to configure the base URL prefix
* Closes #113 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update documentation.
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
