### PR TITLE
Fix issue where test case looks for values in the wrong template file

### DIFF
--- a/application/test/pipeline.go
+++ b/application/test/pipeline.go
@@ -19,10 +19,11 @@ type updatePipeline struct {
 
 func (c *updatePipeline) renderTemplates(_ context.Context) error {
 	err := c.appService.renderService.RenderTemplates(domain.RenderContext{
-		Repository:    c.repo,
-		ValueStore:    c.appService.valueStore,
-		TemplateStore: c.appService.templateStore,
-		Engine:        c.appService.engine,
+		Repository:           c.repo,
+		ValueStore:           c.appService.valueStore,
+		TemplateStore:        c.appService.templateStore,
+		Engine:               c.appService.engine,
+		SkipExtensionRemoval: true,
 	})
 	return err
 }

--- a/application/test/validate.go
+++ b/application/test/validate.go
@@ -27,7 +27,6 @@ func (c *Command) validateTestCommand(ctx *cli.Context) error {
 
 	c.appService.console.SetTitle("RUNNING TESTS...")
 	c.appService.console.SetCommandName("Test")
-	c.appService.templateStore.SkipRemovingFileExtension = true
 	c.appService.repoStore.ParentDir = "tests"
 	c.appService.repoStore.TestOutputRootDir = ".tests"
 	c.appService.repoStore.DefaultNamespace = "local"

--- a/docs/modules/developer-guide/pages/ref-domain.adoc
+++ b/docs/modules/developer-guide/pages/ref-domain.adoc
@@ -773,14 +773,17 @@ RenderTemplates loads the TemplateStore and renders them in the GitRepository.Ro
 [source, go]
 ----
 type RenderContext struct {
-    Repository       *GitRepository
-    ValueStore       ValueStore
-    TemplateStore    TemplateStore
-    Engine           TemplateEngine
+    Repository              *GitRepository
+    ValueStore              ValueStore
+    TemplateStore           TemplateStore
+    Engine                  TemplateEngine
+    SkipExtensionRemoval    bool
 }
 ----
 
 RenderContext represents a single rendering context for a GitRepository.
+
+
 
 
 
@@ -804,9 +807,8 @@ RenderContext represents a single rendering context for a GitRepository.
 [source, go]
 ----
 type Template struct {
-    RelativePath            Path
-    FilePermissions         Permissions
-    ExtensionReplacement    string
+    RelativePath       Path
+    FilePermissions    Permissions
 }
 ----
 
@@ -818,9 +820,6 @@ RelativePath is the Path reference to where the template file is contained withi
 FilePermissions::
 FilePermissions defines what file permissions this template file has.
 Rendered files should have the same permissions as template files.
-
-ExtensionReplacement::
-ExtensionReplacement is a substring that is removed from the file path.
 
 
 
@@ -1255,7 +1254,7 @@ var ErrKeyNotFound = errors.New("key not found")
 ErrKeyNotFound is an error that indicates that a particular key was not found.
 
 
-=== DefaultExtensionReplacement
+=== FileExtensionReplacement
 [source, go]
 ----
 

--- a/domain/render_service.go
+++ b/domain/render_service.go
@@ -17,10 +17,11 @@ type RenderService struct {
 
 // RenderContext represents a single rendering context for a GitRepository.
 type RenderContext struct {
-	Repository    *GitRepository
-	ValueStore    ValueStore
-	TemplateStore TemplateStore
-	Engine        TemplateEngine
+	Repository           *GitRepository
+	ValueStore           ValueStore
+	TemplateStore        TemplateStore
+	Engine               TemplateEngine
+	SkipExtensionRemoval bool
 
 	instrumentation RenderServiceInstrumentation
 	templates       []*Template
@@ -87,6 +88,9 @@ func (ctx *RenderContext) renderTemplate(template *Template) error {
 	}
 
 	targetPath := template.CleanPath()
+	if ctx.SkipExtensionRemoval {
+		targetPath = template.RelativePath
+	}
 	if alternativePath != "" {
 		targetPath = alternativePath
 	}

--- a/domain/template.go
+++ b/domain/template.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-var DefaultExtensionReplacement = ".tpl"
+var FileExtensionReplacement = ".tpl"
 
 // Permissions is an alias for file permissions.
 type Permissions fs.FileMode
@@ -19,16 +19,13 @@ type Template struct {
 	// FilePermissions defines what file permissions this template file has.
 	// Rendered files should have the same permissions as template files.
 	FilePermissions Permissions
-	// ExtensionReplacement is a substring that is removed from the file path.
-	ExtensionReplacement string
 }
 
 // NewTemplate returns a new instance.
 func NewTemplate(relPath Path, perms Permissions) *Template {
 	return &Template{
-		RelativePath:         relPath,
-		FilePermissions:      perms,
-		ExtensionReplacement: DefaultExtensionReplacement,
+		RelativePath:    relPath,
+		FilePermissions: perms,
 	}
 }
 
@@ -42,7 +39,7 @@ func (t *Template) Render(values Values, engine TemplateEngine) (RenderResult, e
 func (t *Template) CleanPath() Path {
 	dirName := path.Dir(t.RelativePath.String())
 	baseName := path.Base(t.RelativePath.String())
-	newName := strings.Replace(baseName, t.ExtensionReplacement, "", 1)
+	newName := strings.Replace(baseName, FileExtensionReplacement, "", 1)
 	return NewPath(dirName, newName)
 }
 

--- a/domain/template_test.go
+++ b/domain/template_test.go
@@ -35,11 +35,6 @@ func TestTemplate_CleanPath(t *testing.T) {
 			givenPath:    NewPath("readme.md.tpl.tpl"),
 			expectedPath: NewPath("readme.md.tpl"),
 		},
-		"GivenFile_WhenExtensionReplacementGiven_ThenRemoveOne": {
-			givenExtensionReplacement: ".other",
-			givenPath:                 NewPath("readme.md.other.tpl"),
-			expectedPath:              NewPath("readme.md.tpl"),
-		},
 		"GivenFileInDir_WhenExtension_ThenRemoveFromFileName": {
 			givenPath:    NewPath("dir", "readme.tpl.md"),
 			expectedPath: NewPath("dir", "readme.md"),
@@ -48,9 +43,6 @@ func TestTemplate_CleanPath(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			template := NewTemplate(tt.givenPath, Permissions(0))
-			if tt.givenExtensionReplacement != "" {
-				template.ExtensionReplacement = tt.givenExtensionReplacement
-			}
 			result := template.CleanPath()
 			assert.Equal(t, tt.expectedPath, result)
 		})

--- a/infrastructure/templateengine/gotemplate/store.go
+++ b/infrastructure/templateengine/gotemplate/store.go
@@ -8,8 +8,7 @@ import (
 )
 
 type GoTemplateStore struct {
-	RootDir                   string
-	SkipRemovingFileExtension bool
+	RootDir string
 }
 
 func NewTemplateStore() *GoTemplateStore {
@@ -50,8 +49,5 @@ func (s *GoTemplateStore) evaluatePath(file string, info os.FileInfo, err error)
 		domain.NewPath(relativePath),
 		domain.Permissions(info.Mode()),
 	)
-	if s.SkipRemovingFileExtension {
-		tpl.ExtensionReplacement = ""
-	}
 	return tpl, nil
 }

--- a/infrastructure/valuestore/koanfstore_test.go
+++ b/infrastructure/valuestore/koanfstore_test.go
@@ -52,7 +52,7 @@ func TestKoanfStore_loadAndMergeConfig(t *testing.T) {
 	}
 }
 
-func TestKoanfStore_LoadDataForTemplate(t *testing.T) {
+func TestKoanfStore_loadValuesForTemplate(t *testing.T) {
 	tests := map[string]struct {
 		expectedConf          domain.Values
 		givenSyncFile         string


### PR DESCRIPTION
## Summary

* Follow up of #171
* related to how file extension removal works

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
