### PR TITLE
Do not render templates that are going to be deleted

### DIFF
--- a/application/test/main.go
+++ b/application/test/main.go
@@ -41,11 +41,7 @@ func (c *Command) createRepositoryPipeline(r *domain.GitRepository) *pipeline.Pi
 		}),
 		pipeline.NewStepFromFunc("create dir", up.createOutputDir),
 		pipeline.NewStepFromFunc("copy sync file", up.copySyncFile),
-		pipeline.NewPipeline().AddBeforeHook(logger.Accept).
-			WithNestedSteps("render",
-				pipeline.NewStepFromFunc("render templates", up.renderTemplates),
-				pipeline.NewStepFromFunc("cleanup unwanted files", up.cleanupUnwantedFiles),
-			),
+		pipeline.NewStepFromFunc("render templates", up.renderTemplates),
 
 		pipeline.NewStepFromFunc("show diff", up.diff),
 	)

--- a/application/test/pipeline.go
+++ b/application/test/pipeline.go
@@ -44,15 +44,6 @@ func (c *updatePipeline) createOutputDir(_ context.Context) error {
 	return os.MkdirAll(c.repo.RootDir.String(), 0775)
 }
 
-func (c *updatePipeline) cleanupUnwantedFiles(_ context.Context) error {
-	err := c.appService.cleanupService.CleanupUnwantedFiles(domain.CleanupPipeline{
-		Repository:    c.repo,
-		ValueStore:    c.appService.valueStore,
-		TemplateStore: c.appService.templateStore,
-	})
-	return err
-}
-
 func (c *updatePipeline) copySyncFile(_ context.Context) error {
 	return c.appService.repoStore.CopySyncFile(c.repo)
 }

--- a/docs/modules/developer-guide/pages/ref-domain.adoc
+++ b/docs/modules/developer-guide/pages/ref-domain.adoc
@@ -798,6 +798,7 @@ RenderContext represents a single rendering context for a GitRepository.
 
 
 
+
 **Receivers**
 
 
@@ -1396,6 +1397,7 @@ If nr is nil, then nil is returned.
 ----
 func NewRenderService(instrumentation RenderServiceInstrumentation) *RenderService
 ----
+
 
 
 


### PR DESCRIPTION
## Summary

* Skips rendering of files that are going to be deleted. Normally not an issue, but if the template cannot be rendered due to missing values, it would abort with an error, even if the intention is to remove the file.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `fix`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
